### PR TITLE
FERR-72: Leverage element range indexes

### DIFF
--- a/src/main/ml-config/security/amps/range-index-utils-get-indexes.json
+++ b/src/main/ml-config/security/amps/range-index-utils-get-indexes.json
@@ -1,0 +1,7 @@
+{
+  "namespace": "http://marklogic.com/data-explore/lib/range-index-utils",
+  "local-name": "get-indexes",
+  "document-uri": "/server/lib/range-index-utils.xqy",
+  "modules-database": "%%MODULES_DATABASE%%",
+  "role": ["data-explorer-ext-amp-role"]
+}

--- a/src/main/ml-config/security/roles/data-explorer-ext-amp-role.json
+++ b/src/main/ml-config/security/roles/data-explorer-ext-amp-role.json
@@ -35,6 +35,10 @@
     "action" : "http://marklogic.com/xdmp/privileges/admin-module-read",
     "kind" : "execute"
   }, {
+    "privilege-name" : "admin-database",
+    "action" : "http://marklogic.com/xdmp/privileges/admin/database",
+    "kind" : "execute"
+  }, {
     "privilege-name" : "data-explorer-access",
     "action" : "http://marklogic.com/ps/data-explorer-access",
     "kind" : "execute"

--- a/src/main/ml-modules/root/client/app/adhoc/adhoc.controller.js
+++ b/src/main/ml-modules/root/client/app/adhoc/adhoc.controller.js
@@ -11,6 +11,8 @@ factory('$click', function() {
 	  };
 	})	
   .controller('AdhocCtrl', function($scope, $http, $sce, Auth, User, AdhocState,$window,$timeout,$click) {
+    var ctrl = this;
+
     // Determine if we arrived here from a back button click
     var displayLastResults = AdhocState.getDisplayLastResults();
     // Restore the saved state
@@ -19,6 +21,24 @@ factory('$click', function() {
     $scope.$watch('currentPage', function(page){
       AdhocState.setPage(page);
     });  
+
+    ctrl.suggestValues = function(field) {
+      return $http.get('/api/suggest-values', {
+        params: {
+          database: $scope.selectedDatabase,
+          rangeIndex: field.item.rangeIndex,
+          qtext: field.value
+        }
+      })
+      .then(function(response) {
+        if (response.data && response.data.values) {
+          return response.data.values;
+        }
+        else {
+          return [];
+        }
+      });
+    };
 
     $scope.to_trusted = function(html_code) {
       return $sce.trustAsHtml(html_code);

--- a/src/main/ml-modules/root/client/app/adhoc/adhoc.html
+++ b/src/main/ml-modules/root/client/app/adhoc/adhoc.html
@@ -30,8 +30,12 @@
           </div>
           <div ng-show="textFields.length">
             <div ng-repeat="item in textFields" class="form-group">
-              <label for="input{{index+1}}">{{item}}</label>
-              <input type="text" class="form-control" ng-model="inputField[$index+1]" id="input{{index+1}}" placeholder="{{item}}"/>
+              <label for="input{{ index + 1 }}">
+                {{ item.label }}
+                <span class="index-indicator" ng-if="item.rangeIndex" tooltip="This element currently has a range index.">*</span>
+              </label>
+              <input ng-if="!item.rangeIndex" type="text" class="form-control" ng-model="inputField[$index + 1]" id="input{{ $index + 1 }}" placeholder="{{ item.label }}"/>
+              <input ng-if="item.rangeIndex" type="text" class="form-control" ng-model="inputField[$index + 1]" id="input{{ $index + 1 }}" placeholder="{{ item.label }}" autocomplete="off" typeahead="suggestion for suggestion in ctrl.suggestValues({ value: $viewValue, item: item })"/>
             </div>
             <button type="submit" ng-click="clickSearch(form)" class="btn btn-default">Search</button>
           </div>

--- a/src/main/ml-modules/root/client/app/adhoc/adhoc.js
+++ b/src/main/ml-modules/root/client/app/adhoc/adhoc.js
@@ -7,6 +7,7 @@ angular.module('demoApp')
         url: '/adhoc',
         templateUrl: 'app/adhoc/adhoc.html',
         controller: 'AdhocCtrl',
+        controllerAs: 'ctrl',
         authenticate: true
       });
   });

--- a/src/main/ml-modules/root/client/css/app.css
+++ b/src/main/ml-modules/root/client/css/app.css
@@ -32,3 +32,8 @@
 
 .multi-value-box:first-child { border-top: 0px; }
 .multi-value-box:not(:first-child) {  border-top: 1px solid; border-color: #ddd;}
+
+.index-indicator {
+  color: #ff0000;
+  font-weight: bold;
+}

--- a/src/main/ml-modules/root/server/endpoints/adhoc/api-adhoc-selectors.xqy
+++ b/src/main/ml-modules/root/server/endpoints/adhoc/api-adhoc-selectors.xqy
@@ -21,7 +21,7 @@ declare function local:get-queries-views-json($db as xs:string, $doctype as xs:s
 
     let $queries-array-sequence := 
         for $q in $queries
-        let $options := to-json:seq-to-array-json(to-json:string-sequence-to-json(lib-adhoc:get-query-form-items($doctype,$q)))
+        let $options := xdmp:quote(lib-adhoc:get-query-form-items($doctype, $q))
         return to-json:xml-obj-to-json(<output><query>{$q}</query><form-options>{$options}</form-options></output>)
 
     let $queries-json := to-json:seq-to-array-json($queries-array-sequence)

--- a/src/main/ml-modules/root/server/endpoints/adhoc/api-adhoc-suggest-values.xqy
+++ b/src/main/ml-modules/root/server/endpoints/adhoc/api-adhoc-suggest-values.xqy
@@ -1,0 +1,24 @@
+xquery version "1.0-ml";
+
+import module namespace  check-user-lib = "http://www.marklogic.com/data-explore/lib/check-user-lib" at "/server/lib/check-user-lib.xqy" ;
+import module namespace cfg = "http://www.marklogic.com/data-explore/lib/config" at "/server/lib/config.xqy";
+import module namespace riu = "http://marklogic.com/data-explore/lib/range-index-utils" at "/server/lib/range-index-utils.xqy";
+
+
+declare function local:get-json() {
+  let $database := map:get($cfg:getRequestFieldsMap, "database")
+  let $index := map:get($cfg:getRequestFieldsMap, "rangeIndex")
+  let $match-text := map:get($cfg:getRequestFieldsMap, "qtext")
+  let $values := riu:match-index-values($match-text, $database, $index, 10)
+
+  let $json := json:object()
+
+  return (
+    map:put($json, "values", json:to-array($values)),
+    xdmp:quote($json)
+  )
+};
+
+if (check-user-lib:is-logged-in() and (check-user-lib:is-search-user() or check-user-lib:is-wizard-user())) 
+then (local:get-json())
+else (xdmp:set-response-code(401, "User is not authorized."))

--- a/src/main/ml-modules/root/server/lib/adhoc-create-lib.xqy
+++ b/src/main/ml-modules/root/server/lib/adhoc-create-lib.xqy
@@ -100,10 +100,11 @@ declare function lib-adhoc-create:create-edit-form-query($adhoc-fields as map:ma
 		  	let $mode := map:get($adhoc-fields, fn:concat("formLabelIncludeMode", $i))
 		  	return
 		  		if (fn:exists($label) and ($mode eq "both" or $mode eq "query")) then
-		  		  let $_ := map:put($form-fields-map, fn:concat("id", $counter), map:get($adhoc-fields, fn:concat("formLabelHidden", $i)))
+		  			let $field-path := map:get($adhoc-fields, fn:concat("formLabelHidden", $i))
+		  		  let $_ := map:put($form-fields-map, fn:concat("id", $counter), $field-path)
 		  		  let $_ := xdmp:set($counter, $counter + 1)
 		  		  return
-		  			<formLabel>{ $label }</formLabel>
+		  			<formLabel expr="{ $field-path }" mode="{ $mode }">{ $label }</formLabel>
 		  		else
 		  			()
 		  }

--- a/src/main/ml-modules/root/server/lib/adhoc-lib.xqy
+++ b/src/main/ml-modules/root/server/lib/adhoc-lib.xqy
@@ -1,8 +1,12 @@
 xquery version "1.0-ml";
 
 module namespace lib-adhoc = "http://marklogic.com/data-explore/lib/adhoc-lib";
-import module namespace cfg = "http://www.marklogic.com/data-explore/lib/config"
-  at "/server/lib/config.xqy";
+import module namespace cfg = "http://www.marklogic.com/data-explore/lib/config" at "/server/lib/config.xqy";
+import module namespace json = "http://marklogic.com/xdmp/json" at "/MarkLogic/json/json.xqy";
+import module namespace riu = "http://marklogic.com/data-explore/lib/range-index-utils" at "/server/lib/range-index-utils.xqy";
+
+declare namespace db = "http://marklogic.com/xdmp/database";
+
 
 declare function lib-adhoc:get-databases() as xs:string*{
 	for $db in fn:distinct-values(
@@ -39,6 +43,22 @@ declare function lib-adhoc:get-view-names($database as xs:string, $docType as xs
 	return $names
 };
 
-declare function lib-adhoc:get-query-form-items($docType as xs:string, $query as xs:string) as xs:string*{
-	cfg:get-form-query($docType, $query)/formLabel
+declare function lib-adhoc:get-query-form-items($doc-type as xs:string, $query as xs:string) as json:array {
+	let $form-query-doc := cfg:get-form-query($doc-type, $query)
+	let $database := $form-query-doc/database/fn:string()
+
+	let $form-options := for $option in $form-query-doc/formLabel
+		let $form-field := fn:tokenize($option/@expr, "/")[fn:last()]
+	  let $range-index := riu:get-index($database, $form-field)
+	  let $json := json:object()
+	  return (
+	  	map:put($json, "label", $option/fn:string()),
+	  	if (fn:empty($range-index)) then () else (
+	  		map:put($json, "rangeIndex", $form-field), (: this will be used to query for index values :)
+	  		map:put($json, "scalarType", $range-index/db:scalar-type/fn:string())
+	  	),
+	  	$json
+	  )
+
+	return json:to-array($form-options)
 };

--- a/src/main/ml-modules/root/server/lib/endpoints.xqy
+++ b/src/main/ml-modules/root/server/lib/endpoints.xqy
@@ -22,6 +22,7 @@ declare variable $endpoints:API-USERS           as xs:string := "/server/endpoin
 declare variable $endpoints:API-ADHOC-DATABASES as xs:string := "/server/endpoints/adhoc/api-adhoc-databases.xqy";
 declare variable $endpoints:API-ADHOC-SELECTORS as xs:string := "/server/endpoints/adhoc/api-adhoc-selectors.xqy";
 declare variable $endpoints:API-SEARCH          as xs:string := "/server/endpoints/adhoc/api-adhoc-search.xqy";
+declare variable $endpoints:API-SUGGEST-VALUES  as xs:string := "/server/endpoints/adhoc/api-adhoc-suggest-values.xqy";
 declare variable $endpoints:API-ADHOC-WIZARD as xs:string := "/server/endpoints/adhoc/wizard/api-adhoc-query-wizard.xqy";
 declare variable $endpoints:API-ADHOC-WIZARD-CREATE as xs:string := "/server/endpoints/adhoc/wizard/api-adhoc-query-wizard-create.xqy";
 
@@ -88,6 +89,12 @@ declare variable $endpoints:ENDPOINTS as element(rest:options) :=
             <param name="pagination-size"/>
             <param name="exportCsv"/>
             <http method="POST"/>
+            <http method="GET"/>
+        </request>
+        <request uri="^/api/suggest-values$" endpoint="{ $endpoints:API-SUGGEST-VALUES }">
+            <param name="database"/>
+            <param name="rangeIndex"/>
+            <param name="qtext"/>
             <http method="GET"/>
         </request>
         <request uri="^/api/wizard/upload$" endpoint="{$endpoints:API-ADHOC-WIZARD}">

--- a/src/main/ml-modules/root/server/lib/range-index-utils.xqy
+++ b/src/main/ml-modules/root/server/lib/range-index-utils.xqy
@@ -1,0 +1,58 @@
+xquery version "1.0-ml";
+
+module namespace riu = "http://marklogic.com/data-explore/lib/range-index-utils";
+
+import module namespace admin = "http://marklogic.com/xdmp/admin" at "/MarkLogic/admin.xqy";
+import module namespace cfg = "http://www.marklogic.com/data-explore/lib/config" at "/server/lib/config.xqy";
+import module namespace functx = "http://www.functx.com" at "/MarkLogic/functx/functx-1.0-nodoc-2007-01.xqy";
+
+declare namespace db = "http://marklogic.com/xdmp/database";
+
+
+declare function riu:get-indexes($database as xs:string)
+as node()* 
+{
+  (: maybe cache this later on (if too expensive)? :)
+  let $admin-config := admin:get-configuration()
+  return <range-indexes>{ admin:database-get-range-element-indexes($admin-config, xdmp:database($database)) }</range-indexes>
+};
+
+declare function riu:form-field-to-qname($form-field as xs:string)
+as xs:QName*
+{
+  let $ns := cfg:getNamespaceUri(fn:substring-before($form-field, ":"))
+  let $localname := fn:substring-after($form-field, ":")
+  return fn:QName($ns, $localname)
+};
+
+declare function riu:get-index($database as xs:string, $form-field as xs:string)
+as node()* 
+{
+  let $indexes := riu:get-indexes($database)
+  let $qname := riu:form-field-to-qname($form-field)
+  return fn:head($indexes/db:range-element-index[db:namespace-uri eq fn:namespace-uri-from-QName($qname) 
+    and db:localname eq fn:local-name-from-QName($qname)])
+};
+
+declare function riu:match-index-values($match-text as xs:string*, $database as xs:string, $form-field as xs:string, $limit as xs:integer*)
+as xs:anyAtomicType*
+{
+  let $max-items := fn:max(($limit, 10)[1], 1)
+  let $qtext := functx:trim($match-text)
+  let $index := riu:get-index($database, $form-field)
+
+  return xdmp:invoke-function(function() {
+    cts:element-value-match(
+      riu:form-field-to-qname($form-field),
+      if (fn:string-length($qtext) gt 0) then fn:concat("*", $match-text, "*") else "*",
+      (
+        "case-insensitive", "frequency-order",
+        fn:concat("limit=", $max-items),
+        fn:concat("collation=", $index/db:collation/fn:string())
+      )
+    )
+  },
+  <options xmlns="xdmp:eval">
+    <database>{ xdmp:database($database) }</database>
+  </options>)
+};

--- a/src/main/ml-modules/root/server/lib/range-index-utils.xqy
+++ b/src/main/ml-modules/root/server/lib/range-index-utils.xqy
@@ -5,6 +5,7 @@ module namespace riu = "http://marklogic.com/data-explore/lib/range-index-utils"
 import module namespace admin = "http://marklogic.com/xdmp/admin" at "/MarkLogic/admin.xqy";
 import module namespace cfg = "http://www.marklogic.com/data-explore/lib/config" at "/server/lib/config.xqy";
 import module namespace functx = "http://www.functx.com" at "/MarkLogic/functx/functx-1.0-nodoc-2007-01.xqy";
+import module namespace xu = "http://marklogic.com/data-explore/lib/xdmp-utils" at "/server/lib/xdmp-utils.xqy"; 
 
 declare namespace db = "http://marklogic.com/xdmp/database";
 
@@ -37,11 +38,11 @@ as node()*
 declare function riu:match-index-values($match-text as xs:string*, $database as xs:string, $form-field as xs:string, $limit as xs:integer*)
 as xs:anyAtomicType*
 {
-  let $max-items := fn:max(($limit, 10)[1], 1)
+  let $max-items := fn:max((($limit, 10)[1], 1))
   let $qtext := functx:trim($match-text)
   let $index := riu:get-index($database, $form-field)
 
-  return xdmp:invoke-function(function() {
+  return xu:invoke-function(function() {
     cts:element-value-match(
       riu:form-field-to-qname($form-field),
       if (fn:string-length($qtext) gt 0) then fn:concat("*", $match-text, "*") else "*",


### PR DESCRIPTION
- Added typeahead to form fields that have available element range indexes
- Added new endpoint to supply suggested values

NOTES:
- The changes required additions to the query document (added attributes to the <formLabel> element); any old or existing queries will still work, but won't utilize indexes even if there's an appropriate one.  In the meantime, users can (re)create the queries.
- A small red asterisk beside the field name indicates that it will use an index and provide typeahead.

TODO:
- Typeahead really only works best with strings.
- Need to consider using different UI components/directives for number and date/time scalar types; perhaps using ranges?
- There's probably a better way to indicate a field has an index (rather than a red asterisk).