### PR TITLE
FERR-65 JSON Support

### DIFF
--- a/ferret.iml
+++ b/ferret.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="ferret" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="Ferret" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">

--- a/src/main/ml-config/security/roles/data-explorer-wizard-role.json
+++ b/src/main/ml-config/security/roles/data-explorer-wizard-role.json
@@ -6,5 +6,9 @@
     "privilege-name" : "data-explorer-access",
     "action" : "http://marklogic.com/ps/data-explorer-access",
     "kind" : "execute"
+  },{
+    "privilege-name" : "xdmp-value",
+    "action" : "http://marklogic.com/xdmp/privileges/xdmp-value",
+    "kind" : "execute"
   }]
 }

--- a/src/main/ml-config/security/roles/data-explorer-wizard-role.json
+++ b/src/main/ml-config/security/roles/data-explorer-wizard-role.json
@@ -6,9 +6,5 @@
     "privilege-name" : "data-explorer-access",
     "action" : "http://marklogic.com/ps/data-explorer-access",
     "kind" : "execute"
-  },{
-    "privilege-name" : "xdmp-value",
-    "action" : "http://marklogic.com/xdmp/privileges/xdmp-value",
-    "kind" : "execute"
   }]
 }

--- a/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard.controller.js
+++ b/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard.controller.js
@@ -220,3 +220,4 @@ function isNamespaceAwareMimeType(mimeType) {
 
 function isSupportedFileType(mimeType) {
     return getFileType(mimeType) >= 0;
+};

--- a/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard.controller.js
+++ b/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard.controller.js
@@ -20,7 +20,8 @@ angular.module('demoApp')
     $scope.isNamespaceAware = true;
     $scope.showNamespaces = false;
     $scope.filename = '';
-    
+    $scope.fileType = 0;
+
     $scope.toggleNamespaces = function() {
     	$scope.showNamespaces = !$scope.showNamespaces;
     }
@@ -86,6 +87,7 @@ angular.module('demoApp')
         $scope.wizardUploadFormData.append('type',$scope.queryView);
         var fileMimeType = $scope.wizardUploadFormData.get('mimeType');
         $scope.isNamespaceAware = isNamespaceAwareMimeType(fileMimeType)
+        $scope.fileType = getFileType(fileMimeType)
         if ( !isSupportedFileType(fileMimeType) ) {
               $scope.message = "This file-type is not supported. Choose a different file";
               $scope.uploadButtonActive = false;
@@ -149,7 +151,7 @@ angular.module('demoApp')
         data.rootElement = $scope.wizardForm.rootElement;
 
         data.database = $scope.formInput.selectedDatabase;
-                
+        data.fileType =  $scope.fileType;
         if ($scope.wizardForm.type.toLowerCase() === 'query'){
             data.queryName = $scope.formInput.queryViewName;
 
@@ -158,6 +160,7 @@ angular.module('demoApp')
             	if($scope.wizardForm.fields[i-1].include){
             		data['formLabel'+counter] = $scope.wizardForm.fields[i-1].title;
             		data['formLabelHidden'+counter] = $scope.wizardForm.fields[i-1].xpathNormal;
+            		data['formLabelDataType'+counter] = $scope.wizardForm.fields[i-1].dataType;
             		data['formLabelIncludeMode' + counter] = $scope.wizardForm.fields[i-1].includeMode;
             		counter += 1;
             	}
@@ -172,6 +175,7 @@ angular.module('demoApp')
             	if($scope.wizardForm.fields[i-1].include){
 	                data['columnName'+counter] = $scope.wizardForm.fields[i-1].title;
 	                data['columnExpr'+counter] = $scope.wizardForm.fields[i-1].xpathNormal;
+            		data['columnDataType'+counter] = $scope.wizardForm.fields[i-1].dataType;
 	        		data['columnIncludeMode' + counter] = $scope.wizardForm.fields[i-1].includeMode;
 	        		counter += 1;
             	}
@@ -202,10 +206,18 @@ angular.module('demoApp')
 
   });
 
+function getFileType(mimeType) {
+    if ( mimeType === "text/xml" || mimeType == "application/xml" ) {
+       return 0;
+    } else if ( mimeType == "application/json" ) {
+           return 1;
+    }
+    return -1;
+}
 function isNamespaceAwareMimeType(mimeType) {
-    return mimeType === "text/xml" || mimeType == "application/xml"
+    return getFileType(mimeType) == 0;
 }
 
 function isSupportedFileType(mimeType) {
-    return mimeType === "text/xml" || mimeType == "application/xml" || mimeType == "application/json"
+    return getFileType(mimeType) >= 0;
 };

--- a/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard.controller.js
+++ b/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard.controller.js
@@ -220,4 +220,3 @@ function isNamespaceAwareMimeType(mimeType) {
 
 function isSupportedFileType(mimeType) {
     return getFileType(mimeType) >= 0;
-};

--- a/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard.controller.js
+++ b/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard.controller.js
@@ -17,6 +17,7 @@ angular.module('demoApp')
 
     $scope.inputField = {};
 
+    $scope.isNamespaceAware = true;
     $scope.showNamespaces = false;
     $scope.filename = '';
     
@@ -53,6 +54,7 @@ angular.module('demoApp')
             } else {
                 $scope.message = "Select the desired mode and press the create button";
                 $scope.wizardUploadFormData.append("uploadedDoc", files[0]);
+                $scope.wizardUploadFormData.append("mimeType", files[0]['type']);
                 $scope.messageClass = "form-group"
                 $scope.uploadButtonActive = true;
             }
@@ -82,7 +84,8 @@ angular.module('demoApp')
             return;
         }
         $scope.wizardUploadFormData.append('type',$scope.queryView);
-        var fileMimeType = $scope.wizardUploadFormData.get('uploadedDoc')['type'];
+        var fileMimeType = $scope.wizardUploadFormData.get('mimeType');
+        $scope.isNamespaceAware = isNamespaceAwareMimeType(fileMimeType)
         if ( !isSupportedFileType(fileMimeType) ) {
               $scope.message = "This file-type is not supported. Choose a different file";
               $scope.uploadButtonActive = false;
@@ -199,6 +202,10 @@ angular.module('demoApp')
 
   });
 
-function isSupportedFileType(mimeType) {
+function isNamespaceAwareMimeType(mimeType) {
     return mimeType === "text/xml" || mimeType == "application/xml"
+}
+
+function isSupportedFileType(mimeType) {
+    return mimeType === "text/xml" || mimeType == "application/xml" || mimeType == "application/json"
 };

--- a/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard.html
+++ b/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard.html
@@ -4,7 +4,7 @@
   <div ng-hide="step != 1" class="row">
       <h1>Step 1 - Upload Example Document XML</h1>
       <div class="wizard-step-detail">
-      	Select a representative file to use that will help define a query and/or view.
+      	Select a representative XML or JSON-file to use that will help define a query and/or view.
       </div>
       <form class="form-horizontal" style="padding-top:10px">
         <div class="form-group">
@@ -75,7 +75,7 @@
 			<div>
 	        	<div ng-if="wizardForm.type == 'Query'" class="wizard-step-detail" style="margin-top:-10px">For each field you may select whether it is available to search on, displayed in results, both, or none.</div>
 	        	<div ng-if="wizardForm.type != 'Query'" class="wizard-step-detail" style="margin-top:-10px">For each field you may select whether it displayed in results or not.</div>
-				<div style="padding-top:5px;padding-bottom:10px">
+				<div ng-show="isNamespaceAware" style="padding-top:5px;padding-bottom:10px">
 					<span>Namespaces ({{wizardForm.namespaces.length}})</span>
 					<span class="glyphicon" style="icon: pointer" ng-class="showNamespaces ? 'glyphicon-chevron-up' : 'glyphicon-chevron-down'"  aria-hidden="true" ng-click="toggleNamespaces()"></span>
 				</div>

--- a/src/main/ml-modules/root/client/app/adhoc/adhoc.controller.js
+++ b/src/main/ml-modules/root/client/app/adhoc/adhoc.controller.js
@@ -103,7 +103,27 @@ factory('$click', function() {
         if (typeof(newValue) !== 'undefined' && newValue != '') {
           for (var i = 0; i < $scope.queries.length; i++) {
             if ($scope.queries[i].query == newValue) {
-              $scope.textFields = $scope.queries[i]['form-options'];
+              var dataTypes = $scope.queries[i]['form-datatypes']
+              var formLabels = $scope.queries[i]['form-labels']
+              var arr = new Array(formLabels.length)
+              for ( i = 0 ; i < formLabels.length ; i++ ) {
+                 var formLabel = formLabels[i]
+                 var dataTypeString = "";
+                 var dt = "text"
+                 if ( i < dataTypes.length ) {
+                    var dataType = dataTypes[i]
+                    dt = dataType
+                    if ( dataType != null && dataType.trim().length > 0 ) {
+                                  dataTypeString = " ("+dataType.trim()+")"
+                     }
+                 }
+                 arr[i] = new Array(3);
+                 arr[i][0] = formLabel;
+                 arr[i][1] = formLabel+dataTypeString
+                 arr[i][2] = dt
+              }
+              $scope.textFields = arr
+              $scope.dataTypes = dataTypes
               break;
             }
           }

--- a/src/main/ml-modules/root/client/app/adhoc/adhoc.html
+++ b/src/main/ml-modules/root/client/app/adhoc/adhoc.html
@@ -30,8 +30,10 @@
           </div>
           <div ng-show="textFields.length">
             <div ng-repeat="item in textFields" class="form-group">
-              <label for="input{{index+1}}">{{item}}</label>
-              <input type="text" class="form-control" ng-model="inputField[$index+1]" id="input{{index+1}}" placeholder="{{item}}"/>
+              <label for="input{{index+1}}">{{ item[0] }}</label>
+              <select ng-if="item[2] == 'boolean'" ng-model="inputField[$index+1]" class="form-control" ng-options="item for item in ['','true', 'false']"></select>
+              <input ng-if="item[2] == 'text'"  type="text" class="form-control" ng-model="inputField[$index+1]" id="input{{index+1}}" placeholder="{{ item[1] }}"/>
+              <input ng-if="item[2] == 'number'"  type="number" class="form-control" ng-model="inputField[$index+1]" id="input{{index+1}}" placeholder="{{ item[1] }}"/>
             </div>
             <button type="submit" ng-click="clickSearch(form)" class="btn btn-default">Search</button>
           </div>

--- a/src/main/ml-modules/root/client/app/detail/detail.controller.js
+++ b/src/main/ml-modules/root/client/app/detail/detail.controller.js
@@ -13,16 +13,18 @@ angular.module('demoApp')
     $scope.database = $stateParams.database;
     $scope.uri      = $stateParams.uri;
     $scope.prettyData = '';
-
+    $scope.tabheading = '';
     $scope.details = Detail.get({database:$scope.database,uri:$scope.uri},function(details){
       $scope.doc = details;
       console.log("ADDA3");
       console.log($scope.doc.mimetype);
-      if ( $scope.doc.mimetype = "application/json") {
+      if ( $scope.doc.mimetype == "application/json") {
         console.log($scope.doc.data);
         $scope.prettyData = vkbeautify.json($scope.doc.data)
+        $scope.tabheading = "JSON View";
       } else {
         $scope.prettyData = vkbeautify.xml($scope.doc.data);
+        $scope.tabheading = "XML View";
       }
     });
 

--- a/src/main/ml-modules/root/client/app/detail/detail.controller.js
+++ b/src/main/ml-modules/root/client/app/detail/detail.controller.js
@@ -16,8 +16,6 @@ angular.module('demoApp')
     $scope.tabheading = '';
     $scope.details = Detail.get({database:$scope.database,uri:$scope.uri},function(details){
       $scope.doc = details;
-      console.log("ADDA3");
-      console.log($scope.doc.mimetype);
       if ( $scope.doc.mimetype == "application/json") {
         console.log($scope.doc.data);
         $scope.prettyData = vkbeautify.json($scope.doc.data)

--- a/src/main/ml-modules/root/client/app/detail/detail.controller.js
+++ b/src/main/ml-modules/root/client/app/detail/detail.controller.js
@@ -12,11 +12,18 @@ angular.module('demoApp')
 
     $scope.database = $stateParams.database;
     $scope.uri      = $stateParams.uri;
-    $scope.prettyXML = '';
+    $scope.prettyData = '';
 
     $scope.details = Detail.get({database:$scope.database,uri:$scope.uri},function(details){
       $scope.doc = details;
-      $scope.prettyXML = vkbeautify.xml($scope.doc.xml);
+      console.log("ADDA3");
+      console.log($scope.doc.mimetype);
+      if ( $scope.doc.mimetype = "application/json") {
+        console.log($scope.doc.data);
+        $scope.prettyData = vkbeautify.json($scope.doc.data)
+      } else {
+        $scope.prettyData = vkbeautify.xml($scope.doc.data);
+      }
     });
 
     $scope.to_trusted = function(html_code) {

--- a/src/main/ml-modules/root/client/app/detail/detail.html
+++ b/src/main/ml-modules/root/client/app/detail/detail.html
@@ -12,7 +12,6 @@
 		    				</div>
 		    			</div>
 		    		</tab>
-
 		    		<tab heading="{{tabheading}}" active="false"><br/>
 		    			<a class="btn btn-default xml-button" target="_blank" href="/api/get-xml-doc/{{database}}/{{uri}}" role="button"><span class="glyphicon glyphicon-share" aria-hidden="true"></span>XML-Only Page</a><br/>
 		    			<code>{{prettyData}}</code>

--- a/src/main/ml-modules/root/client/app/detail/detail.html
+++ b/src/main/ml-modules/root/client/app/detail/detail.html
@@ -14,7 +14,7 @@
 		    		</tab>
 
 		    		<tab heading="XML View" active="false"><br/>
-		    			<a class="btn btn-default xml-button" href="/api/get-xml-doc/{{database}}/{{uri}}" role="button"><span class="glyphicon glyphicon-share" aria-hidden="true"></span>XML-Only Page</a><br/>
+		    			<a class="btn btn-default xml-button" target="_blank" href="/api/get-xml-doc/{{database}}/{{uri}}" role="button"><span class="glyphicon glyphicon-share" aria-hidden="true"></span>XML-Only Page</a><br/>
 		    			<code>{{prettyXML}}</code>
 		    		</tab>
 		    	</tabset>

--- a/src/main/ml-modules/root/client/app/detail/detail.html
+++ b/src/main/ml-modules/root/client/app/detail/detail.html
@@ -13,7 +13,7 @@
 		    			</div>
 		    		</tab>
 
-		    		<tab heading="XML View" active="false"><br/>
+		    		<tab heading="{{tabheading}}" active="false"><br/>
 		    			<a class="btn btn-default xml-button" target="_blank" href="/api/get-xml-doc/{{database}}/{{uri}}" role="button"><span class="glyphicon glyphicon-share" aria-hidden="true"></span>XML-Only Page</a><br/>
 		    			<code>{{prettyData}}</code>
 		    		</tab>

--- a/src/main/ml-modules/root/client/app/detail/detail.html
+++ b/src/main/ml-modules/root/client/app/detail/detail.html
@@ -15,7 +15,7 @@
 
 		    		<tab heading="XML View" active="false"><br/>
 		    			<a class="btn btn-default xml-button" target="_blank" href="/api/get-xml-doc/{{database}}/{{uri}}" role="button"><span class="glyphicon glyphicon-share" aria-hidden="true"></span>XML-Only Page</a><br/>
-		    			<code>{{prettyXML}}</code>
+		    			<code>{{prettyData}}</code>
 		    		</tab>
 		    	</tabset>
 		    </div>

--- a/src/main/ml-modules/root/server/endpoints/adhoc/api-adhoc-search.xqy
+++ b/src/main/ml-modules/root/server/endpoints/adhoc/api-adhoc-search.xqy
@@ -124,8 +124,12 @@ declare function local:get-result()
     else
       ()
 
-  return
-    search-lib:search($searchParams,$database,($export-csv eq "true"))
+  let $ret := search-lib:search($searchParams,$database,($export-csv eq "true"))
+  let $_ := if ( $cfg:D ) then
+              xdmp:log(("Returned from search-lib",$ret))
+            else
+              ()
+  return $ret
 };
 
 declare function local:get-json(){
@@ -167,7 +171,12 @@ declare function local:get-json(){
           <max-export-records>{$cfg:max-export-records}</max-export-records>
           <results>{$results-json}</results>
         </output>
-      return to-json:xml-obj-to-json($output)
+      let $json := to-json:xml-obj-to-json($output)
+      let $_ := if ( $cfg:D ) then
+                    xdmp:log(("Search result JSON",$json))
+                else
+                    ()
+      return $json
   };
   
 declare function local:get-csv(){

--- a/src/main/ml-modules/root/server/endpoints/adhoc/api-adhoc-selectors.xqy
+++ b/src/main/ml-modules/root/server/endpoints/adhoc/api-adhoc-selectors.xqy
@@ -2,6 +2,7 @@ xquery version "1.0-ml";
 import module namespace lib-adhoc = "http://marklogic.com/data-explore/lib/adhoc-lib" at "/server/lib/adhoc-lib.xqy";
 import module namespace to-json = "http://marklogic.com/data-explore/lib/to-json" at "/server/lib/to-json-lib.xqy";
 import module namespace  check-user-lib = "http://www.marklogic.com/data-explore/lib/check-user-lib" at "/server/lib/check-user-lib.xqy" ;
+import module namespace cfg = "http://www.marklogic.com/data-explore/lib/config"  at "/server/lib/config.xqy";
 
 (: Expected output 
 
@@ -21,8 +22,10 @@ declare function local:get-queries-views-json($db as xs:string, $doctype as xs:s
 
     let $queries-array-sequence := 
         for $q in $queries
-        let $options := to-json:seq-to-array-json(to-json:string-sequence-to-json(lib-adhoc:get-query-form-items($doctype,$q)))
-        return to-json:xml-obj-to-json(<output><query>{$q}</query><form-options>{$options}</form-options></output>)
+        let $form-items := lib-adhoc:get-query-form-items($doctype,$q)
+        let $labels := to-json:seq-to-array-json(to-json:string-sequence-to-json($form-items/label))
+        let $datatypes := to-json:seq-to-array-json(to-json:string-sequence-to-json($form-items/dataType))
+        return to-json:xml-obj-to-json(<output><query>{$q}</query><form-labels>{$labels}</form-labels><form-datatypes>{$datatypes}</form-datatypes></output>)
 
     let $queries-json := to-json:seq-to-array-json($queries-array-sequence)
     let $views-json   := to-json:seq-to-array-json(to-json:string-sequence-to-json($views))
@@ -38,12 +41,17 @@ declare function local:get-json(){
 	let $db 	 := $tokens[4] (:Since there can be multiple databases with name variations but same doctypes/views:)
 	let $doctype := xdmp:url-decode( $tokens[5] )
 
-	return 
+	let $output :=
 		if (fn:empty($doctype) or $doctype = "") then
 			local:get-doctypes-json($db)
 		else
 			local:get-queries-views-json($db,$doctype)
+    let $_ := if ($cfg:D) then
+        xdmp:log(("Returning Selector JSON:",$output))
+    else ()
+    return $output
 };
+
 let $_ := xdmp:log("FROM: /server/endpoints/adhoc/api-adhoc-selectors.xqy","debug")
 return
        if (check-user-lib:is-logged-in() and (check-user-lib:is-search-user() or check-user-lib:is-wizard-user())) then

--- a/src/main/ml-modules/root/server/endpoints/adhoc/wizard/api-adhoc-query-wizard-create.xqy
+++ b/src/main/ml-modules/root/server/endpoints/adhoc/wizard/api-adhoc-query-wizard-create.xqy
@@ -8,6 +8,7 @@ import module namespace lib-adhoc-create = "http://marklogic.com/data-explore/li
 import module namespace  check-user-lib = "http://www.marklogic.com/data-explore/lib/check-user-lib" at "/server/lib/check-user-lib.xqy" ;
 
 
+let $_ := xdmp:log("START: /server/endpoints/adhoc/wizard/api-adhoc-query-wizard-create.xqy","debug")
 let $create-form := map:get($cfg:getRequestFieldsMap, "queryText")
 let $_ := 
 	if(map:contains($cfg:getRequestFieldsMap, "queryName")) then 
@@ -20,11 +21,11 @@ let $_ :=
 				let $_ := 
 					for $key in map:keys($cfg:getRequestFieldsMap)
 					return 
-					if(fn:starts-with($key,"formLabelHidden")) then
+					if(fn:matches($key,"formLabelHidden[0-9]")) then
 						map:put($defaultViewMap, "columnExpr"||fn:tokenize($key,"[A-z]")[fn:last()], map:get($cfg:getRequestFieldsMap, $key))
-					else if(fn:starts-with($key, "formLabelIncludeMode")) then
+					else if(fn:matches($key, "formLabelIncludeMode[0-9]")) then
 						map:put($defaultViewMap, "columnIncludeMode"||fn:tokenize($key,"[A-z]")[fn:last()], map:get($cfg:getRequestFieldsMap, $key))
-					else if (fn:starts-with($key, "formLabel")) then 
+					else if (fn:matches($key,"formLabel[0-9]")) then
 						map:put($defaultViewMap, "columnName"||fn:tokenize($key,"[A-z]")[fn:last()], map:get($cfg:getRequestFieldsMap, $key))
 					else(map:put($defaultViewMap, $key, map:get($cfg:getRequestFieldsMap, $key)))
 				return lib-adhoc-create:create-edit-view($defaultViewMap) 

--- a/src/main/ml-modules/root/server/endpoints/adhoc/wizard/api-adhoc-query-wizard.xqy
+++ b/src/main/ml-modules/root/server/endpoints/adhoc/wizard/api-adhoc-query-wizard.xqy
@@ -145,7 +145,7 @@ declare function local:get-children-nodes-json($get-structure as xs:boolean,$pat
                     $i instance of  number-node() or
                     $i instance of boolean-node() or
                     ($i instance of null-node() )) then
-                <child><path>{$finalpath}</path><dataType>{xdmp:node-kind(xdmp:unpath($finalpath,(),fn:root($i)))[1]}</dataType></child>
+                <child><path>{$finalpath}</path><dataType>{xdmp:node-kind($i)}</dataType></child>
             else if ($i instance of object-node() ) then
                 (
                    local:get-children-nodes-json ($get-structure,$finalpath, $i),

--- a/src/main/ml-modules/root/server/endpoints/adhoc/wizard/api-adhoc-query-wizard.xqy
+++ b/src/main/ml-modules/root/server/endpoints/adhoc/wizard/api-adhoc-query-wizard.xqy
@@ -160,7 +160,6 @@ declare function local:get-children-nodes-json($get-structure as xs:boolean,$pat
     return functx:distinct-deep($results)
 };
 
-
 declare function local:render-fields($doc as node(), $type as xs:string,$is-json as xs:boolean) {
     let $label := if ($type eq "query") then "Form Field:" else "Column Name:"
     let $children := if ( $is-json ) then

--- a/src/main/ml-modules/root/server/endpoints/api-detail.xqy
+++ b/src/main/ml-modules/root/server/endpoints/api-detail.xqy
@@ -3,6 +3,7 @@ import module namespace functx = "http://www.functx.com" at "/MarkLogic/functx/f
 import module namespace detail-lib = "http://www.marklogic.com/data-explore/lib/detail-lib" at "/server/lib/detail-lib.xqy";
 import module namespace to-json = "http://marklogic.com/data-explore/lib/to-json" at "/server/lib/to-json-lib.xqy";
 import module namespace  check-user-lib = "http://www.marklogic.com/data-explore/lib/check-user-lib" at "/server/lib/check-user-lib.xqy" ;
+import module namespace cfg = "http://www.marklogic.com/data-explore/lib/config"  at "/server/lib/config.xqy";
 
 (: Expected output 
 
@@ -25,7 +26,7 @@ import module namespace  check-user-lib = "http://www.marklogic.com/data-explore
    
  };
 
-declare function local:render-document($node) {
+declare function local:render-document-xml($node) {
     typeswitch($node)
         case text() return <span class="value">{$node}</span>
         case element() 
@@ -48,9 +49,35 @@ declare function local:render-document($node) {
 declare function local:recurse($node) {
     for $child in ($node/node(),$node/@*)
     return
-        local:render-document($child)
+        local:render-document-xml($child)
 };
 
+declare function local:render-document-json($the-node) {
+    for $node in $the-node
+    return
+        if ($node instance of text() or
+                $node instance of  number-node() or
+                $node instance of boolean-node()  ) then
+            <span class="value">{$node/fn:string()}</span>
+        else if ($node instance of object-node() ) then
+            for $child in $node/node()
+            return <div class="element">
+                <span class="element-label">{fn:name($child)  }</span>
+                {local:render-document-json($child)}
+            </div>
+        else if ($node instance of array-node()) then
+                <div class="element">
+                    {for $child in $node/node()
+                     return <div class="element">
+                                {local:render-document-json($child)}
+                             </div>}
+                </div>
+            else (
+                    <div class="element">
+                        {local:render-document-json($node/node())}
+                    </div>
+                )
+};
 
 declare function local:get-json($uri as xs:string, $db as xs:string){
     let $content-type := detail-lib:get-document-content-type($uri,$db)
@@ -58,13 +85,19 @@ declare function local:get-json($uri as xs:string, $db as xs:string){
                            detail-lib:get-document($uri,$db)/element()
                         else
                             detail-lib:get-document($uri,$db)
-    let $rawDoc     := xdmp:quote(local:render-document(detail-lib:get-document($uri,$db)))
+    let $rawDoc     := if ( $content-type = "application/xml") then
+                             xdmp:quote(local:render-document-xml(detail-lib:get-document($uri,$db)))
+                        else
+                            xdmp:quote(local:render-document-json(detail-lib:get-document($uri,$db)))
     let $docText    := fn:normalize-space(fn:replace(xdmp:quote($rawDoc),'"', '\\"'))
-    let $docData     := fn:normalize-space(fn:replace(xdmp:quote($doc),'"', '\\"'))
+    let $docData     :=  fn:normalize-space(fn:replace(xdmp:quote($doc),'"', '\\"'))
+    let $docData     := if ( $content-type = "application/xml") then $docData else fn:concat('"',$docData,'"')
 	let $doctype 	 := fn:local-name( $doc )
     let $collections :=detail-lib:get-collections($uri,$db)
 	let $permissions :=detail-lib:get-permissions($uri,$db)
-	let $related-map 	 :=detail-lib:find-related-items-by-document($doc,$db)
+	let $related-map 	 :=if ( $content-type = "application/xml") then
+                             detail-lib:find-related-items-by-document($doc,$db)
+                           else () (: TODO for JSON :)
     let $related-items-json :=
         for $key in map:keys($related-map)
         let $values := to-json:seq-to-array-json(to-json:string-sequence-to-json(map:get($related-map,$key)))
@@ -88,6 +121,9 @@ declare function local:get-json($uri as xs:string, $db as xs:string){
         </output>
 
     let $json := to-json:xml-obj-to-json($xml)
+    let $_ := if ($cfg:D) then
+                        xdmp:log(("Returning Detail JSON:",$json))
+              else ()
 	return $json
 };
 

--- a/src/main/ml-modules/root/server/endpoints/api-detail.xqy
+++ b/src/main/ml-modules/root/server/endpoints/api-detail.xqy
@@ -53,10 +53,14 @@ declare function local:recurse($node) {
 
 
 declare function local:get-json($uri as xs:string, $db as xs:string){
-	let $doc 		 :=detail-lib:get-document($uri,$db)/element()
+    let $content-type := detail-lib:get-document-content-type($uri,$db)
+    let $doc 		 := if ( $content-type = "application/xml") then
+                           detail-lib:get-document($uri,$db)/element()
+                        else
+                            detail-lib:get-document($uri,$db)
     let $rawDoc     := xdmp:quote(local:render-document(detail-lib:get-document($uri,$db)))
     let $docText    := fn:normalize-space(fn:replace(xdmp:quote($rawDoc),'"', '\\"'))
-    let $docXml     := fn:normalize-space(fn:replace(xdmp:quote($doc),'"', '\\"'))
+    let $docData     := fn:normalize-space(fn:replace(xdmp:quote($doc),'"', '\\"'))
 	let $doctype 	 := fn:local-name( $doc )
     let $collections :=detail-lib:get-collections($uri,$db)
 	let $permissions :=detail-lib:get-permissions($uri,$db)
@@ -78,8 +82,9 @@ declare function local:get-json($uri as xs:string, $db as xs:string){
             <collections>{$collections-json}</collections>
             <permissions>{$permissions-json}</permissions>
             <text>{$docText}</text>
-            <xml>{$docXml}</xml>
+            <data>{$docData}</data>
             <related>{$related-json}</related>
+            <mimetype>{$content-type}</mimetype>
         </output>
 
     let $json := to-json:xml-obj-to-json($xml)

--- a/src/main/ml-modules/root/server/lib/adhoc-create-lib.xqy
+++ b/src/main/ml-modules/root/server/lib/adhoc-create-lib.xqy
@@ -1,8 +1,9 @@
 xquery version "1.0-ml";
 
 module namespace lib-adhoc-create = "http://marklogic.com/data-explore/lib/adhoc-create-lib";
-import module namespace cfg = "http://www.marklogic.com/data-explore/lib/config"at "/server/lib/config.xqy";
-import module namespace xu = "http://marklogic.com/data-explore/lib/xdmp-utils" at "/server/lib/xdmp-utils.xqy"; 
+import module namespace cfg = "http://www.marklogic.com/data-explore/lib/config" at "/server/lib/config.xqy";
+import module namespace xu = "http://marklogic.com/data-explore/lib/xdmp-utils" at "/server/lib/xdmp-utils.xqy";
+import module namespace const = "http://www.marklogic.com/data-explore/lib/const" at "/server/lib/const.xqy";
 
 
 declare  namespace sec="http://marklogic.com/xdmp/security";
@@ -13,12 +14,24 @@ declare variable $form-fields-map :=
 	return $form-map
 ;
 
-declare function lib-adhoc-create:get-elementname($xpath as xs:string, $position as xs:string){
+declare variable $data-types-map :=
+let $dt-map := map:map()
+return $dt-map
+;
+
+declare function lib-adhoc-create:get-elementname($file-type as xs:string,$xpath as xs:string, $position as xs:string){
   let $tokens := fn:tokenize($xpath, "/")
   let $elementname :=
     if ($position eq "last") then
       $tokens[fn:last()]
-    else if($position eq "root") then $tokens[1] else $tokens[2]
+    else if($position eq "root") then
+	    if ($file-type = $const:FILE_TYPE_XML) then
+		  $tokens[1]
+		else if ( $file-type = $const:FILE_TYPE_JSON) then
+		  "/"
+		else ()
+	else
+		()
   return $elementname
 };
 
@@ -26,26 +39,44 @@ declare function lib-adhoc-create:create-params($i){
   fn:concat('let $param', $i, ' := map:get($params, "id', $i, '")')
 };
 
-declare function lib-adhoc-create:create-evq($i, $xpath as xs:string){
- let $elementname := lib-adhoc-create:get-elementname($xpath, "last")
+declare function lib-adhoc-create:create-ewq($file-type as xs:string,$data-type as xs:string,$i, $xpath as xs:string) {
+ let $elementname := lib-adhoc-create:get-elementname($file-type,$xpath, "last")
  return
- fn:concat('if ($param', $i, ') then cts:element-value-query(xs:QName("', $elementname, '"), $param', $i, ')
+	  if ( $file-type = $const:FILE_TYPE_XML) then
+ 			fn:concat('if ($param', $i, ') then cts:element-word-query(xs:QName("', $elementname, '"), $param', $i, ')
             else ()')
+	  else   if ( $file-type = $const:FILE_TYPE_JSON) then
+	      if ( $data-type = $const:DATA_TYPE_TEXT ) then
+		    fn:concat('if ($param', $i, ') then cts:json-property-word-query("', $elementname, '", fn:string($param', $i, '))
+               else ()')
+		  else if ( $data-type = $const:DATA_TYPE_NUMBER ) then
+			  fn:concat('if ($param', $i, ') then cts:json-property-value-query("', $elementname, '", xs:decimal($param', $i, '))
+               else ()')
+		  else if ( $data-type = $const:DATA_TYPE_BOOLEAN ) then
+				  fn:concat('if ($param', $i, ') then cts:json-property-value-query("', $elementname, '", xs:boolean($param', $i, '))
+               else ()')
+		  else
+				  ()
+	  else
+		  ()
 };
-declare function lib-adhoc-create:create-ewq($i, $xpath as xs:string){
- let $elementname := lib-adhoc-create:get-elementname($xpath, "last")
+declare function lib-adhoc-create:create-eq($file-type as xs:string,$xpath as xs:string, $params){
+ let $elementname := lib-adhoc-create:get-elementname($file-type,$xpath, "root")
  return
- fn:concat('if ($param', $i, ') then cts:element-word-query(xs:QName("', $elementname, '"), $param', $i, ')
-            else ()')
-};
-declare function lib-adhoc-create:create-eq($xpath as xs:string, $params){
- let $elementname := lib-adhoc-create:get-elementname($xpath, "root")
- return
- fn:concat('cts:element-query(
-      xs:QName("', $elementname, '"), cts:and-query((',  $params, ',if ($word) then
-      cts:word-query($word, "case-insensitive")
-    else
-      ())))')
+	 if ( $file-type = $const:FILE_TYPE_XML ) then
+		 fn:concat('cts:element-query(
+  		    xs:QName("', $elementname, '"), cts:and-query((',  $params, ',if ($word) then
+  			    cts:word-query($word, "case-insensitive")
+ 			   else
+      		())))')
+	 else if ( $file-type = $const:FILE_TYPE_JSON ) then
+		 fn:concat('cts:and-query((',  $params, ',if ($word) then
+  			    cts:json-property-word-query($word, "case-insensitive")
+ 			   else
+      		()))')
+	 else
+		 ()
+
 };
 
 declare function lib-adhoc-create:file-name($query-name as xs:string)
@@ -64,7 +95,7 @@ declare function lib-adhoc-create:create-edit-form-query($adhoc-fields as map:ma
 	let $query-name := map:get($adhoc-fields, "queryName")
 	let $querytext := map:get($adhoc-fields, "queryText")
 	let $database := map:get($adhoc-fields, "database")
-
+	let $file-type := map:get($adhoc-fields, "fileType")
 
 	let $uri :=
 		(: For the filename, only use the local name of the last item in the XPath :)
@@ -72,7 +103,7 @@ declare function lib-adhoc-create:create-edit-form-query($adhoc-fields as map:ma
 		return fn:string-join(
 			(
 				"", "adhoc", 
-				if($prefix) then $prefix else(""), 
+				if($prefix) then $prefix else (),
 				$clean-element, 
 				"forms-queries", 
 				lib-adhoc-create:file-name($query-name)
@@ -101,20 +132,21 @@ declare function lib-adhoc-create:create-edit-form-query($adhoc-fields as map:ma
 		  	return
 		  		if (fn:exists($label) and ($mode eq "both" or $mode eq "query")) then
 		  		  let $_ := map:put($form-fields-map, fn:concat("id", $counter), map:get($adhoc-fields, fn:concat("formLabelHidden", $i)))
-		  		  let $_ := xdmp:set($counter, $counter + 1)
+		          let $_ := map:put($data-types-map, fn:concat("id", $counter), map:get($adhoc-fields, fn:concat("formLabelDataType", $i)))
+		          let $_ := xdmp:set($counter, $counter + 1)
 		  		  return
 		  			<formLabel>{ $label }</formLabel>
 		  		else
 		  			()
 		  }
-		  <code>{if($querytext) then $querytext else lib-adhoc-create:create-edit-form-code($adhoc-fields)}</code>
+		  <code>{if($querytext) then $querytext else lib-adhoc-create:create-edit-form-code($file-type,$adhoc-fields)}</code>
 		</formQuery>
   let $_ := xu:document-insert($uri, $form-query)
 
 	return fn:true()
 };
 
-declare function lib-adhoc-create:create-edit-form-code($adhoc-fields as map:map){
+declare function lib-adhoc-create:create-edit-form-code($file-type as xs:string,$adhoc-fields as map:map){
 	  let $params :=
 	    for $key in map:keys($form-fields-map)
 	    return lib-adhoc-create:create-params(fn:substring($key, 3))
@@ -122,11 +154,11 @@ declare function lib-adhoc-create:create-edit-form-code($adhoc-fields as map:map
 	  let $word-query := fn:concat('let $word := map:get($params, "word")', fn:codepoints-to-string(10), 'return', fn:codepoints-to-string(10))
 	  let $evqs :=
 	    for $key in map:keys($form-fields-map)
-    	return lib-adhoc-create:create-ewq(fn:substring($key, 3),  map:get($form-fields-map, $key))
+    	return lib-adhoc-create:create-ewq($file-type,map:get($data-types-map,$key),fn:substring($key, 3),  map:get($form-fields-map, $key))
     return (
     	$params,
     	$word-query,
-    	lib-adhoc-create:create-eq(
+    	lib-adhoc-create:create-eq($file-type,
     		map:get($adhoc-fields, fn:concat("formLabelHidden", 1)),
     		fn:string-join($evqs, fn:concat(",", fn:codepoints-to-string(10)))
       )
@@ -145,10 +177,11 @@ declare function lib-adhoc-create:create-edit-view($adhoc-fields as map:map)
 			let $uri :=
 				(: For the filename, only use the local name of the last item in the XPath :)
 				let $clean-element := fn:replace( fn:tokenize($root-element, "/")[fn:last()], "^.+?:", "")
+				let $clean-element := if ($clean-element) then $clean-element else ()
 				return fn:string-join(
 					(
 						"", "adhoc", 
-						if($prefix) then $prefix else(""), 
+						if($prefix) then $prefix else (),
 						$clean-element, 
 						"views", 
 						lib-adhoc-create:file-name($view-name)

--- a/src/main/ml-modules/root/server/lib/adhoc-create-lib.xqy
+++ b/src/main/ml-modules/root/server/lib/adhoc-create-lib.xqy
@@ -4,7 +4,7 @@ module namespace lib-adhoc-create = "http://marklogic.com/data-explore/lib/adhoc
 import module namespace cfg = "http://www.marklogic.com/data-explore/lib/config" at "/server/lib/config.xqy";
 import module namespace xu = "http://marklogic.com/data-explore/lib/xdmp-utils" at "/server/lib/xdmp-utils.xqy";
 import module namespace const = "http://www.marklogic.com/data-explore/lib/const" at "/server/lib/const.xqy";
-
+import module namespace lib-adhoc = "http://marklogic.com/data-explore/lib/adhoc-lib" at "/server/lib/adhoc-lib.xqy";
 
 declare  namespace sec="http://marklogic.com/xdmp/security";
 
@@ -211,7 +211,7 @@ declare function lib-adhoc-create:create-edit-view($adhoc-fields as map:map)
 				  	let $mode := map:get($adhoc-fields, "columnIncludeMode" || $i)
 				  	return
 				  		if (fn:exists($name) and fn:exists($expr) and ($mode eq "both" or $mode eq "view")) then
-				  			<column name="{ $name }" evaluateAs="XPath" expr="{ $expr }" />
+				  			<column name="{ $name }" evaluateAs="XPath" expr="{ lib-adhoc:transform-xpath-with-spaces($expr) }" />
 				  		else
 				  			()
 				  }

--- a/src/main/ml-modules/root/server/lib/adhoc-create-lib.xqy
+++ b/src/main/ml-modules/root/server/lib/adhoc-create-lib.xqy
@@ -128,6 +128,7 @@ declare function lib-adhoc-create:create-edit-form-query($adhoc-fields as map:ma
 		  	let $counter := 1
 		  	for $i in (1 to 250)
 		  	let $label := map:get($adhoc-fields, fn:concat("formLabel", $i))
+			let $datatype := map:get($adhoc-fields,fn:concat("formLabelDataType",$i))
 		  	let $mode := map:get($adhoc-fields, fn:concat("formLabelIncludeMode", $i))
 		  	return
 		  		if (fn:exists($label) and ($mode eq "both" or $mode eq "query")) then
@@ -135,7 +136,7 @@ declare function lib-adhoc-create:create-edit-form-query($adhoc-fields as map:ma
 		          let $_ := map:put($data-types-map, fn:concat("id", $counter), map:get($adhoc-fields, fn:concat("formLabelDataType", $i)))
 		          let $_ := xdmp:set($counter, $counter + 1)
 		  		  return
-		  			<formLabel>{ $label }</formLabel>
+		  			<formLabel><label>{ $label }</label><dataType>{ $datatype }</dataType></formLabel>
 		  		else
 		  			()
 		  }

--- a/src/main/ml-modules/root/server/lib/adhoc-lib.xqy
+++ b/src/main/ml-modules/root/server/lib/adhoc-lib.xqy
@@ -39,6 +39,6 @@ declare function lib-adhoc:get-view-names($database as xs:string, $docType as xs
 	return $names
 };
 
-declare function lib-adhoc:get-query-form-items($docType as xs:string, $query as xs:string) as xs:string*{
-	cfg:get-form-query($docType, $query)/formLabel
+declare function lib-adhoc:get-query-form-items($docType as xs:string, $query as xs:string) as node()* {
+	cfg:get-form-query($docType, $query)//formLabel
 };

--- a/src/main/ml-modules/root/server/lib/adhoc-lib.xqy
+++ b/src/main/ml-modules/root/server/lib/adhoc-lib.xqy
@@ -4,6 +4,16 @@ module namespace lib-adhoc = "http://marklogic.com/data-explore/lib/adhoc-lib";
 import module namespace cfg = "http://www.marklogic.com/data-explore/lib/config"
   at "/server/lib/config.xqy";
 
+declare function lib-adhoc:transform-xpath-with-spaces($xpath as xs:string) {
+	fn:string-join(
+			for $i in fn:tokenize($xpath,"/")
+			return if (fn:contains($i,' ')) then
+				fn:concat("*[name(.) = '",$i,"']")
+			else
+				$i
+			,'/')
+};
+
 declare function lib-adhoc:get-databases() as xs:string*{
 	for $db in fn:distinct-values(
 				for $server in xdmp:servers()

--- a/src/main/ml-modules/root/server/lib/config.xqy
+++ b/src/main/ml-modules/root/server/lib/config.xqy
@@ -19,7 +19,7 @@ declare variable $cfg:pagesize := 10;
 declare variable $cfg:max-export-records := 1000;
 
 (: does some debug logging when true :)
-declare variable $D := fn:false();
+declare variable $D := fn:true();
 
 declare variable $cfg:NS-IGNORE-LIST := ("http://www.w3.org/XML/1998/namespace");
 
@@ -50,7 +50,14 @@ declare variable $cfg:getRequestFieldsMap :=
     for $field in xdmp:get-request-field-names()
     return
      if (xdmp:get-request-field($field)) then
+     (
+       if ( $cfg:D ) then
+          xdmp:log(fn:concat("RequestField '",$field,"' = '",xdmp:get-request-field($field),"'"))
+       else
+          ()
+       ,
        map:put($map, $field, xdmp:get-request-field($field))
+     )
      else
         ()
   return $map

--- a/src/main/ml-modules/root/server/lib/config.xqy
+++ b/src/main/ml-modules/root/server/lib/config.xqy
@@ -19,7 +19,7 @@ declare variable $cfg:pagesize := 10;
 declare variable $cfg:max-export-records := 1000;
 
 (: does some debug logging when true :)
-declare variable $D := fn:true();
+declare variable $D := fn:false();
 
 declare variable $cfg:NS-IGNORE-LIST := ("http://www.w3.org/XML/1998/namespace");
 

--- a/src/main/ml-modules/root/server/lib/const.xqy
+++ b/src/main/ml-modules/root/server/lib/const.xqy
@@ -1,0 +1,11 @@
+xquery version "1.0-ml";
+
+
+module namespace const = "http://www.marklogic.com/data-explore/lib/const";
+
+declare variable $const:FILE_TYPE_XML as xs:string := "0";
+declare variable $const:FILE_TYPE_JSON as xs:string := "1";
+
+declare variable $const:DATA_TYPE_TEXT as xs:string := "text";
+declare variable $const:DATA_TYPE_NUMBER as xs:string := "number";
+declare variable $const:DATA_TYPE_BOOLEAN as xs:string := "boolean";

--- a/src/main/ml-modules/root/server/lib/detail-lib.xqy
+++ b/src/main/ml-modules/root/server/lib/detail-lib.xqy
@@ -90,3 +90,15 @@ declare function detail-lib:get-document($document-uri as xs:string, $db as xs:s
   </options>)
   return $doc
 };
+
+declare function detail-lib:get-document-content-type($document-uri as xs:string, $db as xs:string){
+    let $doc := xu:eval(
+            'xquery version "1.0-ml";
+  declare variable $document-uri as xs:string external;
+  xdmp:uri-content-type($document-uri)',
+            (xs:QName("document-uri"),$document-uri),
+            <options xmlns="xdmp:eval">
+                <database>{xdmp:database($db)}</database>
+            </options>)
+    return $doc
+};

--- a/src/main/ml-modules/root/server/lib/endpoints.xqy
+++ b/src/main/ml-modules/root/server/lib/endpoints.xqy
@@ -92,7 +92,8 @@ declare variable $endpoints:ENDPOINTS as element(rest:options) :=
         </request>
         <request uri="^/api/wizard/upload$" endpoint="{$endpoints:API-ADHOC-WIZARD}">
             <param name="uploadedDoc"/>
-            <param name="type"/>                  
+            <param name="mimeType"/>
+            <param name="type"/>
             <http method="POST"/>
         </request>
         <request uri="^/api/wizard/create$" endpoint="{$endpoints:API-ADHOC-WIZARD-CREATE}">

--- a/src/main/ml-modules/root/server/lib/endpoints.xqy
+++ b/src/main/ml-modules/root/server/lib/endpoints.xqy
@@ -99,11 +99,13 @@ declare variable $endpoints:ENDPOINTS as element(rest:options) :=
         <request uri="^/api/wizard/create$" endpoint="{$endpoints:API-ADHOC-WIZARD-CREATE}">
             <param name="prefix"/>
             <param name="rootElement"/>
+            <param name="fileType"/>
             <param name="queryName"/>
             <param name="viewName"/>
             <param name="queryText"/>
             <param name="database"/>   
             <param name="submit"/>
+            {endpoints:numbered-params("formLabelDataType", (1 to 250))}
             {endpoints:numbered-params("formLabel", (1 to 250))}
             {endpoints:numbered-params("formLabelHidden", (1 to 250))}
             {endpoints:numbered-params("formLabelIncludeMode", (1 to 250))}

--- a/src/main/ml-modules/root/server/lib/search-lib.xqy
+++ b/src/main/ml-modules/root/server/lib/search-lib.xqy
@@ -199,7 +199,7 @@ declare function search-lib:search($params as map:map, $useDB as xs:string,$expo
           if( fn:contains($expr, '$') ) then
             $expr
           else
-            fn:concat('$doc/', $expr)
+            fn:concat('$doc/', $expr,'/fn:string()')
         let $values := xdmp:value(fn:string($expr)) ! fn:normalize-space(.)
         return
           <part><name>{fn:normalize-space($name)}</name>{$values ! <value>{fn:string(.)}</value>}</part>")


### PR DESCRIPTION
- Damon example JSON did not work. Root cause: spaces in attribute names, which causes XPath failures ("//one/second with space/third" is not working). This is solved by transforming xpaths with spaces to something that does work. 

- xdmp:value priv is not needed anymore, because I did an xdmp:unpath which was not really necessary.

Please merge ASAP. 