### PR TITLE
adding style so search page takes up all real estate

### DIFF
--- a/src/main/ml-modules/root/client/app/adhoc/adhoc.html
+++ b/src/main/ml-modules/root/client/app/adhoc/adhoc.html
@@ -1,6 +1,6 @@
 <div ng-include="'components/navbar/navbar.html'"></div>
 
-<div class="container">
+<div class="container-fluid">
   <div class="row">
     <form name="form">
       <div class="col-md-3">


### PR DESCRIPTION
Changed style on just the search page to take up all available width. Table still has the horizontal scroll if need be but page uses all available space. I think I prefer this over the other option which would be to let the table (and other items like export button) extend beyond the viewport of the browser so the horizontal scroll would be on the entire page rather than just the table. Anyone have a preference?