### PR TITLE
103 - Buttons/Links inconsistently use ellipses

### DIFF
--- a/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard-field-selection.controller.js
+++ b/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard-field-selection.controller.js
@@ -23,7 +23,7 @@ angular.module('demoApp')
     $scope.insertView = $scope.editMode && $scope.queryView == "view" && $scope.loadViewName.length == 0
     $scope.updateView = $scope.editMode && $scope.queryView == "view" && $scope.loadViewName.length > 0
     $scope.insertQuery = $scope.queryView == "query" && $scope.editMode == false
-    $scope.buttonText = ($scope.insertView || $scope.insertQuery) ? "Save..." : "Update...";
+    $scope.buttonText = ($scope.insertView || $scope.insertQuery) ? "Save" : "Update";
     $scope.uploadButtonActive = false;
     $scope.message = "";
     $scope.messageClass = "form-group";

--- a/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard-field-selection.html
+++ b/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard-field-selection.html
@@ -112,7 +112,7 @@
 	        </div>
 			<div class="form-group">
 				<div class="col-sm-12">
-					<button type="submit"  ng-click="back()" class="btn btn-primary">Back...</button>&nbsp;<button type="submit" ng-click="submitWizard()" ng-disabled="!validForm()" class="btn btn-primary">{{buttonText}}</button>
+					<button type="submit"  ng-click="back()" class="btn btn-primary">Back</button>&nbsp;<button type="submit" ng-click="submitWizard()" ng-disabled="!validForm()" class="btn btn-primary">{{buttonText}}</button>
 				</div>
 			</div>
 

--- a/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard-type-query.html
+++ b/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard-type-query.html
@@ -61,12 +61,12 @@
 
         <div class="col-md-12" ng-if="(docTypeMethod === 'select' && formInput.startingDocType) || (docTypeMethod === 'upload' && uploadButtonActive)">
           <div class="form-group">
-			  <button ng-click="back()" class="btn btn-primary">Back...</button>&nbsp;<input type="submit" value="Select fields..." ng-click="selectDocumentType()" class="btn btn-primary"/>
+			  <button ng-click="back()" class="btn btn-primary">Back</button>&nbsp;<input type="submit" value="Select fields" ng-click="selectDocumentType()" class="btn btn-primary"/>
 		  </div>
         </div>
 		  <div class="col-md-12" ng-if="!((docTypeMethod === 'select' && formInput.startingDocType) || (docTypeMethod === 'upload' && uploadButtonActive))">
 			  <div class="form-group">
-				   <button ng-click="back()" class="btn btn-primary">Back...</button>
+				   <button ng-click="back()" class="btn btn-primary">Back</button>
 			  </div>
 		  </div>
       </form>

--- a/src/main/ml-modules/root/client/app/adhoc/adhoc.controller.js
+++ b/src/main/ml-modules/root/client/app/adhoc/adhoc.controller.js
@@ -278,7 +278,7 @@ factory('$click', function() {
       	pageNumber= $scope.queryCurrentPage
       }
       if(!exportCsv){
-    	$scope.message = 'Searching....';
+    	$scope.message = 'Searching...';
     	$scope.results = {};
       }
       $scope.includeMatches = !!$scope.searchText || _.some($scope.inputField || []);

--- a/src/main/ml-modules/root/client/app/adhoc/adhoc.html
+++ b/src/main/ml-modules/root/client/app/adhoc/adhoc.html
@@ -45,7 +45,7 @@
       </div>
       <div class="col-md-9">
         <div class="input-group search-box">
-          <input type="text" class="form-control" ng-model="searchText" placeholder="Search text.." aria-label="...">
+          <input type="text" class="form-control" ng-model="searchText" placeholder="Search text" aria-label="Search text">
           <span class="input-group-btn">
             <button class="btn btn-default" type="submit" ng-click="clickSearch(form)">Search!</button>
           </span>
@@ -113,7 +113,7 @@
               </div>
             </div>
             <div ng-show="results['result-count'] == 0">
-              <div class="alert alert-info" role="alert"><strong>Warning!</strong> No data found for given search...</div>
+              <div class="alert alert-info" role="alert"><strong>Warning!</strong> No data found for given search.</div>
             </div>
           </div>
         </div>

--- a/src/main/ml-modules/root/client/app/crud/crud.html
+++ b/src/main/ml-modules/root/client/app/crud/crud.html
@@ -38,18 +38,18 @@
                       <td><span>{{result['docType']}}</span></td>
                       <td>
                                                   <div>
-                                                      <button value="Edit" ng-click="editQuery(result['docType'],result['queryName'])" class="btn btn-primary">Edit...</button>
+                                                      <button value="Edit" ng-click="editQuery(result['docType'],result['queryName'])" class="btn btn-primary">Edit</button>
                                                       &nbsp;
-                                                      <button value="Show views.." ng-click="showViews(result['queryName'],result['docType'],$event)" class="btn btn-primary">Show views...</button></a>
+                                                      <button value="Show views.." ng-click="showViews(result['queryName'],result['docType'],$event)" class="btn btn-primary">Show views</button></a>
                                                       &nbsp;
-                                                      <button value="Remove" ng-click="removeQuery(result['queryName'],result['docType'],$event)" class="btn btn-primary">Remove...</button>
+                                                      <button value="Remove" ng-click="removeQuery(result['queryName'],result['docType'],$event)" class="btn btn-primary">Remove</button>
                                                   </div>
                       </td>
                     </tr>
                   </tbody>
                 </table>
               </div>
-      <button ng-click="createNewQuery()" class="btn btn-primary">Create new query...</button>
+      <button ng-click="createNewQuery()" class="btn btn-primary">Create new query</button>
       <p/>
       <div ng-show="displayViews" >
       </p><legend>List of related non default views of query '{{selectedQueryName}}'</legend>
@@ -84,9 +84,9 @@
                       <td><span>{{result['viewName']}}</span></td>
                       <td>
                           <div>
-                              <button value="Edit" class="btn btn-primary" ng-click="editView(selectedDocType,selectedQueryName,result['viewName'],$event)">Edit...</button>
+                              <button value="Edit" class="btn btn-primary" ng-click="editView(selectedDocType,selectedQueryName,result['viewName'],$event)">Edit</button>
                               &nbsp;
-                              <button value="Remove" ng-click="removeView(selectedQueryName,selectedDocType,result['viewName'],$event)" class="btn btn-primary">Remove...</button>
+                              <button value="Remove" ng-click="removeView(selectedQueryName,selectedDocType,result['viewName'],$event)" class="btn btn-primary">Remove</button>
                           </div>
                       </td>
                   </tr>
@@ -94,7 +94,7 @@
               </table>
           </div>
 
-       <button  class="btn btn-primary" ng-click="editView(selectedDocType,selectedQueryName,'',$event)">Create new view...</button>
+       <button  class="btn btn-primary" ng-click="editView(selectedDocType,selectedQueryName,'',$event)">Create new view</button>
   </div>
 </div>
 </div>

--- a/src/main/ml-modules/root/client/components/navbar/navbar.controller.js
+++ b/src/main/ml-modules/root/client/components/navbar/navbar.controller.js
@@ -9,7 +9,7 @@ angular.module('demoApp')
       'state': 'main'
     }]
     $rootScope.dataExplorerMenu = [{
-      'title': 'Search...',
+      'title': 'Search',
       'state': 'adhoc'
     }];
 

--- a/src/main/ml-modules/root/client/components/navbar/navbar.html
+++ b/src/main/ml-modules/root/client/components/navbar/navbar.html
@@ -23,12 +23,12 @@
           </a>
           <ul class="dropdown-menu" role="menu">
             <li ng-repeat="item in bookmarks">
-              <a href="#" ng-click="openBookmark(item.database,item.queryName,item.docType,item.viewName)">{{item.bookmarkLabel}}...</a>
+              <a href="#" ng-click="openBookmark(item.database,item.queryName,item.docType,item.viewName)">{{item.bookmarkLabel}}</a>
             </li>
           </ul>
         </li>
         <li ng-show="isWizardUser()" ng-class="{active: isActive('/crud')}">
-          <a ui-sref="crud">Edit config...</a>
+          <a ui-sref="crud">Edit config</a>
         </li>
       </ul>
       </ul>

--- a/src/main/ml-modules/root/server/endpoints/adhoc/wizard/api-adhoc-query-wizard.xqy
+++ b/src/main/ml-modules/root/server/endpoints/adhoc/wizard/api-adhoc-query-wizard.xqy
@@ -131,6 +131,6 @@ try {
     
 } catch ($e) {
   ll:trace(
-    ("Error processing uploaded sample doc...", xdmp:quote($e))),
+    ("Error processing uploaded sample doc.", xdmp:quote($e))),
   xdmp:rethrow()
 }


### PR DESCRIPTION
- Ellipses displayed to convey an operation in progress (e.g., loading...) were preserved.
- Instances where an ellipsis appeared as ".." or "...." were converted to "..."
- Ellipses appearing after buttons/links/messages not conveying an operation in progress or truncated text were removed.