### PR TITLE
wizard-user cannot manage queries and views

### DIFF
--- a/src/main/ml-modules/root/server/endpoints/api-crud-get-query-view.xqy
+++ b/src/main/ml-modules/root/server/endpoints/api-crud-get-query-view.xqy
@@ -90,6 +90,6 @@ declare function local:get-query-view() {
     return xdmp:to-json($json)
 };
 
-if (check-user-lib:is-logged-in() and (check-user-lib:is-search-user()))
+if (check-user-lib:is-logged-in() and (check-user-lib:is-wizard-user()))
 then (local:get-query-view())
 else (xdmp:set-response-code(401, "User is not authorized."))

--- a/src/main/ml-modules/root/server/endpoints/api-crud-list-queries.xqy
+++ b/src/main/ml-modules/root/server/endpoints/api-crud-list-queries.xqy
@@ -31,6 +31,6 @@ declare function local:get-queries() {
     return xdmp:to-json($json)
 };
 
-if (check-user-lib:is-logged-in() and ( check-user-lib:is-search-user()))
+if (check-user-lib:is-logged-in() and ( check-user-lib:is-wizard-user()))
 then (local:get-queries())
 else (xdmp:set-response-code(401, "User is not authorized."))

--- a/src/main/ml-modules/root/server/endpoints/api-crud-list-views.xqy
+++ b/src/main/ml-modules/root/server/endpoints/api-crud-list-views.xqy
@@ -30,6 +30,6 @@ declare function local:get-views() {
     return xdmp:to-json($json)
 };
 
-if (check-user-lib:is-logged-in() and (check-user-lib:is-search-user()))
+if (check-user-lib:is-logged-in() and (check-user-lib:is-wizard-user()))
 then (local:get-views())
 else (xdmp:set-response-code(401, "User is not authorized."))


### PR DESCRIPTION
This pull request is for issue #131. When logging in as wizard-user and clicking 'Edit config' in the nav bar, the user was being logged out and taken back to the login page. This was due to api-crud-list-queries.xqy checking to see if the user had the role 'data-explorer-search-role'. Since wizard-user does not have this role, they got bounced to the login page. 

I believe this was just a typo and api-crud-list-queries.xqy should have been checking to see if the user has the 'data-explorer-wizard-role' instead since search users don't have access to the 'Edit config' menu. In researching the issue, I found that api-crud-list-views.xqy (retrieves views for a query) and api-crud-get-query-view.xqy (loads a query to edit it) had the same issue. 

To see the issue:
- Checkout master and do a fresh mldeploy
- Confirm that wizard-user does not have the data-explorer-search-role
- Log in as wizard-user
- Click the 'Edit config' menu in the nav bar
- Confirm you are directed to the login page
- do an mlundeploy

To confirm the fix
- Checkout the issue131 branch and do a fresh mldeploy
- Log in as wizard-user
- Click the 'Edit config' menu in the nav bar
- Confirm you are taken to the list queries page 
- Add a query
- Click the 'Show Views' button
- Confirm any views are retrieved (might be none) and that you are not taken to the login page
- Click the 'Edit' button for a query and confirm you are not taken to the login page