### PR TITLE
144 - Search Results display presents with multiple vertical scroll bars

### DIFF
--- a/src/main/ml-modules/root/client/app/adhoc/adhoc.html
+++ b/src/main/ml-modules/root/client/app/adhoc/adhoc.html
@@ -43,7 +43,7 @@
           </div>
         
       </div>
-      <div class="col-md-9">
+      <div class="col-md-9 search-panel">
         <div class="input-group search-box">
           <input type="text" class="form-control" ng-model="searchText" placeholder="Search text" aria-label="Search text">
           <span class="input-group-btn">
@@ -70,7 +70,7 @@
                 </table>
                 <pagination total-items="results['result-count']" ng-model="queryCurrentPage" max-size="5" class="pagination-sm" boundary-links="true" ng-click="search()"></pagination>
               </div>
-              <div style="overflow-x:auto">
+              <div style="max-height:calc(100vh - 260px); overflow-x:auto; overflow-y:auto;">
                 <table class="table table-bordered">
               	  <thead>
               	    <tr>

--- a/src/main/ml-modules/root/client/css/app.css
+++ b/src/main/ml-modules/root/client/css/app.css
@@ -50,3 +50,10 @@
   color: #ff0000;
   font-weight: bold;
 }
+
+@media (min-width: 992px) {
+  .search-panel {
+    position:fixed ! important;
+    left: 25%;
+  }
+}


### PR DESCRIPTION
- Applied an inline style to set the relative max-height of the table and enable x/y scrolling there.
- Added a style to app.css that keeps the search results panel fixed when scrolling the page.