### PR TITLE
95 - Need error message if user does not have correct roles

### DIFF
--- a/src/main/ml-config/security/users/data-explorer-wizard-user.json
+++ b/src/main/ml-config/security/users/data-explorer-wizard-user.json
@@ -2,5 +2,5 @@
   "user-name": "wizard-user",
   "password": "password",
   "description":"Wizard user for Ferret",
-  "role":["data-explorer-wizard-role"]
+  "role":["data-explorer-wizard-role", "data-explorer-search-role"]
 }

--- a/src/main/ml-modules/root/client/app/account/login/login.controller.js
+++ b/src/main/ml-modules/root/client/app/account/login/login.controller.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('demoApp')
-  .controller('LoginCtrl', function ($scope, $http, Auth, $location, $window) {
+  .controller('LoginCtrl', function ($rootScope, $scope, $http, Auth, $location, $window) {
     $scope.user = {};
     $scope.errors = {};
     Auth.homeMessage = "";
@@ -23,7 +23,7 @@ angular.module('demoApp')
                 } else {
                   Auth.homeMessage = "<span class=\"alert alert-warning\">There are no queries to search. Please contact the Data Explorer admin (Wizard User) to create queries.</span>";
                 }
-                Auth.noQueries = true;
+                $rootScope.noQueries = true;
                 $location.path('/');
               }
               else if(data.queryTemplateExists && data.isSearchUser)

--- a/src/main/ml-modules/root/client/app/account/login/login.controller.js
+++ b/src/main/ml-modules/root/client/app/account/login/login.controller.js
@@ -17,9 +17,12 @@ angular.module('demoApp')
         .then( function() {
           $http.get('/api/checkTemplates').success(function(data, status, headers, config) {
             if (status == 200) {
-              if(!data.queryTemplateExists && data.isSearchUser) {
-                Auth.homeMessage = "There are no queries to search. Please contact the Data Explorer admin (Wizard User) to create queries";
-                Auth.homeMessageClass = "alert alert-warning";
+              if(!data.queryTemplateExists) {
+                if(data.isSearchUser) {
+                  Auth.homeMessage = "<span class=\"alert alert-warning\">There are no queries to search. Please contact the Data Explorer admin (Wizard User) to create queries.</span>";
+                } else if(data.isWizardUser) {
+                  Auth.homeMessage = "<span class=\"alert alert-warning\">There are no queries to search. Please use <a href=\"/crud\">Edit Config</a> to define queries and views.</span>";
+                }
                 Auth.noQueries = true;
                 $location.path('/');
               }

--- a/src/main/ml-modules/root/client/app/account/login/login.controller.js
+++ b/src/main/ml-modules/root/client/app/account/login/login.controller.js
@@ -20,6 +20,7 @@ angular.module('demoApp')
               if(!data.queryTemplateExists && data.isSearchUser) {
                 Auth.homeMessage = "There are no queries to search. Please contact the Data Explorer admin (Wizard User) to create queries";
                 Auth.homeMessageClass = "alert alert-warning";
+                Auth.noQueries = true;
                 $location.path('/');
               }
               else if(data.queryTemplateExists && data.isSearchUser)

--- a/src/main/ml-modules/root/client/app/account/login/login.controller.js
+++ b/src/main/ml-modules/root/client/app/account/login/login.controller.js
@@ -18,10 +18,10 @@ angular.module('demoApp')
           $http.get('/api/checkTemplates').success(function(data, status, headers, config) {
             if (status == 200) {
               if(!data.queryTemplateExists) {
-                if(data.isSearchUser) {
-                  Auth.homeMessage = "<span class=\"alert alert-warning\">There are no queries to search. Please contact the Data Explorer admin (Wizard User) to create queries.</span>";
-                } else if(data.isWizardUser) {
+                if(data.isWizardUser) {
                   Auth.homeMessage = "<span class=\"alert alert-warning\">There are no queries to search. Please use <a href=\"/crud\">Edit Config</a> to define queries and views.</span>";
+                } else {
+                  Auth.homeMessage = "<span class=\"alert alert-warning\">There are no queries to search. Please contact the Data Explorer admin (Wizard User) to create queries.</span>";
                 }
                 Auth.noQueries = true;
                 $location.path('/');

--- a/src/main/ml-modules/root/client/app/account/login/login.controller.js
+++ b/src/main/ml-modules/root/client/app/account/login/login.controller.js
@@ -19,9 +19,9 @@ angular.module('demoApp')
             if (status == 200) {
               if(!data.queryTemplateExists) {
                 if(data.isWizardUser) {
-                  Auth.homeMessage = "<span class=\"alert alert-warning\">There are no queries to search. Please use <a href=\"/crud\">Edit Config</a> to define queries and views.</span>";
+                  Auth.homeMessage = "<div class=\"alert alert-warning\">There are no queries to search. Please use <a href=\"/crud\">Edit Config</a> to define queries and views.</div>";
                 } else {
-                  Auth.homeMessage = "<span class=\"alert alert-warning\">There are no queries to search. Please contact the Data Explorer admin (Wizard User) to create queries.</span>";
+                  Auth.homeMessage = "<div class=\"alert alert-warning\">Please contact a query maintainer who can add new queries that will show here. These users are anyone configured with the \"wizard-user\" role in MarkLogic.</div>";
                 }
                 $rootScope.noQueries = true;
                 $location.path('/');

--- a/src/main/ml-modules/root/client/app/account/login/login.controller.js
+++ b/src/main/ml-modules/root/client/app/account/login/login.controller.js
@@ -19,6 +19,7 @@ angular.module('demoApp')
             if (status == 200) {
               if(!data.queryTemplateExists && data.isSearchUser) {
                 Auth.homeMessage = "There are no queries to search. Please contact the Data Explorer admin (Wizard User) to create queries";
+                Auth.homeMessageClass = "alert alert-warning";
                 $location.path('/');
               }
               else if(data.queryTemplateExists && data.isSearchUser)

--- a/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard-field-selection.controller.js
+++ b/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard-field-selection.controller.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('demoApp')
-  .controller('AdhocWizardFieldSelectionCtrl', function ($state,$scope, $http, $stateParams, $sce, $interval, databaseService, wizardService) {
+  .controller('AdhocWizardFieldSelectionCtrl', function ($rootScope, $state,$scope, $http, $stateParams, $sce, $interval, databaseService, wizardService) {
     if ($stateParams.deparams) {
         $scope.wizardForm = $stateParams.deparams.formData;
         $scope.queryView = $stateParams.deparams.queryView;
@@ -235,6 +235,7 @@ angular.module('demoApp')
                 var crudType = $scope.queryView === 'query' ? 'Query' : 'View';
                 var crudAction = ($scope.insertView || $scope.insertQuery) ? ' created ' : ' updated ';
                 renderResultsModal('success', crudType + crudAction + 'successfully.');
+                $rootScope.noQueries = false;
             }
         }).error(function(data, status){
           renderResultsModal('error', 'Server Error. Please try again later.');

--- a/src/main/ml-modules/root/client/app/main/main.controller.js
+++ b/src/main/ml-modules/root/client/app/main/main.controller.js
@@ -3,5 +3,4 @@
 angular.module('demoApp')
   .controller('MainCtrl', function ($scope, $http, Auth) {
   	$scope.homeMessage = Auth.homeMessage;
-    $scope.homeMessageClass = Auth.homeMessageClass;
   });

--- a/src/main/ml-modules/root/client/app/main/main.controller.js
+++ b/src/main/ml-modules/root/client/app/main/main.controller.js
@@ -3,4 +3,5 @@
 angular.module('demoApp')
   .controller('MainCtrl', function ($scope, $http, Auth) {
   	$scope.homeMessage = Auth.homeMessage;
+    $scope.homeMessageClass = Auth.homeMessageClass;
   });

--- a/src/main/ml-modules/root/client/app/main/main.html
+++ b/src/main/ml-modules/root/client/app/main/main.html
@@ -5,8 +5,8 @@
     <h1>Welcome</h1>
     <span class="lead">Get Ready To Search Your Data! Powered by</span>
     <img src="assets/images/MarkLogic_RGB_72ppitrans.png" alt="MarkLogic">
-    <br/>
-    <span class="lead">{{ homeMessage }}</span>
+    <br/><br/>
+    <span class="lead {{ homeMessageClass }}">{{ homeMessage }}</span>
   </div>
 </header>
 

--- a/src/main/ml-modules/root/client/app/main/main.html
+++ b/src/main/ml-modules/root/client/app/main/main.html
@@ -6,7 +6,7 @@
     <span class="lead">Get Ready To Search Your Data! Powered by</span>
     <img src="assets/images/MarkLogic_RGB_72ppitrans.png" alt="MarkLogic">
     <br/><br/>
-    <span class="lead {{ homeMessageClass }}">{{ homeMessage }}</span>
+    <span class="lead" ng-bind-html="homeMessage"></span>
   </div>
 </header>
 

--- a/src/main/ml-modules/root/client/components/navbar/navbar.controller.js
+++ b/src/main/ml-modules/root/client/components/navbar/navbar.controller.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('demoApp')
-  .controller('NavbarCtrl', function($rootScope, $location, Auth, $cookieStore,$http,$state) {
+  .controller('NavbarCtrl', function($rootScope, $location, Auth, $cookieStore, $http, $state) {
     $rootScope.bookmarks=[]
 
     $rootScope.menu = [{
@@ -10,7 +10,7 @@ angular.module('demoApp')
     }];
 
     // Search is disabled if there are no queries setup.
-    if(!Auth.noQueries) {
+    if(!$rootScope.noQueries) {
       $rootScope.dataExplorerMenu = [{
         'title': 'Search',
         'state': 'adhoc'

--- a/src/main/ml-modules/root/client/components/navbar/navbar.controller.js
+++ b/src/main/ml-modules/root/client/components/navbar/navbar.controller.js
@@ -7,11 +7,15 @@ angular.module('demoApp')
     $rootScope.menu = [{
       'title': 'Home',
       'state': 'main'
-    }]
-    $rootScope.dataExplorerMenu = [{
-      'title': 'Search',
-      'state': 'adhoc'
     }];
+
+    // Search is disabled if there are no queries setup.
+    if(!Auth.noQueries) {
+      $rootScope.dataExplorerMenu = [{
+        'title': 'Search',
+        'state': 'adhoc'
+      }];
+    }
 
     $rootScope.goState = function(state) {
         $state.go(state)

--- a/src/main/ml-modules/root/server/endpoints/api-crud-get-query-view.xqy
+++ b/src/main/ml-modules/root/server/endpoints/api-crud-get-query-view.xqy
@@ -90,6 +90,6 @@ declare function local:get-query-view() {
     return xdmp:to-json($json)
 };
 
-if (check-user-lib:is-logged-in() and (check-user-lib:is-wizard-user()))
+if (check-user-lib:is-logged-in() and check-user-lib:is-search-user())
 then (local:get-query-view())
 else (xdmp:set-response-code(401, "User is not authorized."))

--- a/src/main/ml-modules/root/server/endpoints/api-crud-list-queries.xqy
+++ b/src/main/ml-modules/root/server/endpoints/api-crud-list-queries.xqy
@@ -31,6 +31,6 @@ declare function local:get-queries() {
     return xdmp:to-json($json)
 };
 
-if (check-user-lib:is-logged-in() and ( check-user-lib:is-wizard-user()))
+if (check-user-lib:is-logged-in() and check-user-lib:is-search-user())
 then (local:get-queries())
 else (xdmp:set-response-code(401, "User is not authorized."))

--- a/src/main/ml-modules/root/server/endpoints/api-crud-list-views.xqy
+++ b/src/main/ml-modules/root/server/endpoints/api-crud-list-views.xqy
@@ -30,6 +30,6 @@ declare function local:get-views() {
     return xdmp:to-json($json)
 };
 
-if (check-user-lib:is-logged-in() and (check-user-lib:is-wizard-user()))
+if (check-user-lib:is-logged-in() and check-user-lib:is-search-user())
 then (local:get-views())
 else (xdmp:set-response-code(401, "User is not authorized."))


### PR DESCRIPTION
- Updated login messaging when no queries have been created:
    - Messaging appears in a yellow "warning" alert box.
    - The wizard user is directed to the crud page (with a hyperlink) to create queries.
    - The search user is still directed to have a wizard user create queries.
- The search button on the navigation is now hidden if there are no queries to search.
    - The search button appears as soon as a query is created.
- The wizard user now has a data-explorer-search-role as well (fixed search errors for the wizard user)
- Crud get requests now require the data-explorer-search-role instead of the data-explorer-wizard-role since they are used for searching.