### PR TITLE
Fixing issue #18: added doc counts to DB selection

### DIFF
--- a/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard-field-selection.controller.js
+++ b/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard-field-selection.controller.js
@@ -62,7 +62,11 @@ angular.module('demoApp')
     		}
     });
       databaseService.list().then(function(data) {
-          $scope.availableDatabases = data;
+          var databases = [];
+          for (var key in data) {
+              databases.push(JSON.parse(data[key]));
+          }
+          $scope.availableDatabases = databases;
           if ( $scope.editMode ) {
               wizardService.getQueryView($scope.loadQueryName, $scope.loadDocType,$scope.loadViewName)
                   .success(function (data, status) {

--- a/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard-field-selection.html
+++ b/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard-field-selection.html
@@ -23,7 +23,7 @@
 		      	<div class="form-group">
 		      		<label for="database" class="col-sm-2 control-label">Database</label>
 		      		<div class="col-sm-10">
-			        	<select id="database" ng-disabled="queryView == 'view'" ng-model="formInput.selectedDatabase" name="database" ng-options="database as database for database in availableDatabases" class="form-control" required>
+			        	<select id="database" ng-disabled="queryView == 'view'" ng-model="formInput.selectedDatabase" name="database" ng-options="database.name as database.name + ' (' + database.count + ')' for database in availableDatabases" class="form-control" required>
 			            	<option value="">--Choose Database</option>
 			        	</select>
 		      		</div>

--- a/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard-type-query.controller.js
+++ b/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard-type-query.controller.js
@@ -47,7 +47,11 @@ angular.module('demoApp')
         $scope.wizardUploadFormData = null;
 
         databaseService.list().then(function(data) {
-            $scope.availableDatabases = data;
+            var databases = [];
+            for (var key in data) {
+                databases.push(JSON.parse(data[key]));
+            }
+            $scope.availableDatabases = databases;
         });
         $scope.$watch('docTypeMethod', function() {
             $scope.message = "";
@@ -87,8 +91,12 @@ angular.module('demoApp')
                 transformRequest: angular.identity
             }).success(function(data, status) {
                 if (status == 200) {
+                    var databases = [];
+                    for (var key in data) {
+                        databases.push(JSON.parse(data[key]));
+                    }
                     $scope.wizardForm = {
-                        databases: data
+                        databases: databases
                     };
                     $("#selectDocument").modal();
                 }

--- a/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard-type-query.html
+++ b/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard-type-query.html
@@ -42,7 +42,7 @@
         <div class="col-md-12" ng-if="docTypeMethod === 'select'">
           <div class="form-group">
             <label for="selectDB">Choose a database:</label>
-            <select id="selectDB" class="form-control" ng-model="formInput.selectedDatabase" ng-options="database as database for database in availableDatabases">
+            <select id="selectDB" class="form-control" ng-model="formInput.selectedDatabase" ng-options="database.name as database.name + ' (' + database.count + ')' for database in availableDatabases">
               <option value="">---</option>
             </select>
           </div>
@@ -86,7 +86,7 @@
 		  					<div class="col-sm-3">
 							<div class="input-group input-group-sm">
 							    <select id="database" ng-model="formInput.selectedDatabase" name="database"
-							     ng-options="database as database for database in wizardForm.databases" 
+							     ng-options="database.name as database.name + ' (' + database.count + ')' for database in wizardForm.databases" 
 							     class="form-control pull-right" required>
 						            	<option value="">--Choose Database</option>
 						        	</select>

--- a/src/main/ml-modules/root/client/app/adhoc/adhoc.controller.js
+++ b/src/main/ml-modules/root/client/app/adhoc/adhoc.controller.js
@@ -82,7 +82,11 @@ factory('$click', function() {
 
     $http.get('/api/adhoc').success(function(data, status, headers, config) {
       if (status == 200 && Array.isArray(data)) {
-        $scope.databases = data;
+        var databases = [];
+        for (var key in data) {
+            databases.push(JSON.parse(data[key]));
+        }
+        $scope.databases = databases;
         if ( $scope.loadDatabase != undefined) {
             $scope.selectedDatabase = $scope.loadDatabase;
         }

--- a/src/main/ml-modules/root/client/app/adhoc/adhoc.html
+++ b/src/main/ml-modules/root/client/app/adhoc/adhoc.html
@@ -6,7 +6,7 @@
       <div class="col-md-3">
           <div class="form-group">
             <label>Database</label>
-            <select ng-model="selectedDatabase" ng-options="item as item for item in databases" class="form-control" required>
+            <select ng-model="selectedDatabase" ng-options="item.name as item.name + ' (' + item.count + ')' for item in databases" class="form-control" required>
             	<option value="">--Choose Database</option>
             </select>
           </div>

--- a/src/main/ml-modules/root/server/endpoints/adhoc/api-adhoc-databases.xqy
+++ b/src/main/ml-modules/root/server/endpoints/adhoc/api-adhoc-databases.xqy
@@ -12,11 +12,9 @@ declare option xdmp:mapping "false";
 declare function local:get-json(){
     let $databases := 
     	for $d in lib-adhoc:get-databases()
-    	where fn:not(fn:contains(fn:lower-case($d),"modules"))
-    	return $d
-
-
-    let $array-json := to-json:seq-to-array-json(to-json:string-sequence-to-json($databases))
+    	where fn:not(fn:contains(fn:lower-case($d/name/fn:string()),"modules"))
+    	return xdmp:quote($d)
+    let $array-json := json:to-array($databases)
     return $array-json
 };
 

--- a/src/main/ml-modules/root/server/endpoints/adhoc/wizard/api-adhoc-query-wizard-doc-selection.xqy
+++ b/src/main/ml-modules/root/server/endpoints/adhoc/wizard/api-adhoc-query-wizard-doc-selection.xqy
@@ -59,7 +59,7 @@ declare function local:get-uris-by-root-element-name($element-name, $max-uris,$s
     let $max-uris:=xs:int($max-uris)
     let $max-uris-plus1:=$max-uris+1
     let $query:=
-                let $root-name:=fn:substring(tokenize($element-name,"~")[1],2)
+                let $root-name:=tokenize($element-name,"~")[1]
                 let $ns:=tokenize($element-name,"~")[2]
                 return 
                   <query>


### PR DESCRIPTION
FERR-91: updated the adhoc database query to return the document count
along with the database name. The document count will be comma
separated already. The adhoc database query will now return a JSON
object that has the name and document count stored inside of it.
The document counts will **ONLY** factor in the documents that the user
has access to.

Resolved an issue where the root element document sampling was **NOT**
working properly as no results were being returned with the root
element name specified.

A sample screenshot of the changes implemented for the sampling by root element name is attached below:
![ferr-91](https://user-images.githubusercontent.com/16652599/43055682-f7b0b3da-8e05-11e8-9b8a-743adb154efe.png)