### PR TITLE
Fixing Issue #164: resolve excel column shifts

### DIFF
--- a/src/main/ml-modules/root/server/lib/search-lib.xqy
+++ b/src/main/ml-modules/root/server/lib/search-lib.xqy
@@ -214,7 +214,7 @@ declare function search-lib:search($params as map:map, $useDB as xs:string,$expo
           <current-page>{$page}</current-page>
           <page-count>{search-lib:page-count($search-response)}</page-count>
           <display-order>{$display-order}</display-order>
-          <result-headers><header>URI</header>{for $c in $view/resultFields/resultField return <header>{$c/@label/fn:string()}</header>}</result-headers>
+          <result-headers><header>Database Name</header><header>URI</header>{for $c in $view/resultFields/resultField return <header>{$c/@label/fn:string()}</header>}</result-headers>
           <results>{$results}</results>
         </output>
     else


### PR DESCRIPTION
Resolved the columns shifting to the right by one column in the
exported excel file due to there being no column header for the
database name that is added to the search results