### PR TITLE
fix for databases now coming back with counts

### DIFF
--- a/src/main/ml-modules/root/server/endpoints/adhoc/wizard/api-adhoc-query-wizard.xqy
+++ b/src/main/ml-modules/root/server/endpoints/adhoc/wizard/api-adhoc-query-wizard.xqy
@@ -117,7 +117,7 @@ try {
             to-json:seq-to-array-json(to-json:string-sequence-to-json(local:get-structure($is-json,$uploaded-doc)))
           }</possibleRoots>
 	      <rootElement>{if ($is-json) then "/" else fn:replace(xdmp:path($uploaded-doc/node()), "\[.*\]", "")}</rootElement>
-	      <databases>{to-json:seq-to-array-json(to-json:string-sequence-to-json(lib-adhoc:get-databases()))}</databases>
+	      <databases>{to-json:seq-to-array-json(to-json:string-sequence-to-json(lib-adhoc:get-databases()/name))}</databases>
 	      <namespaces>{ to-json:seq-to-array-json($namespaces) }</namespaces>
 	      <fields>{ $fields }</fields>
 	  </data>


### PR DESCRIPTION
This is for issue #171. Prior to fix doing the following would yield an error:
* Click "Create a Query"
* Choose any option like "Choose a representative XML or JSON file"
* Click "Select Fields" button
* An error is displayed on the screen and the above is in the log.

With fix, the select fields screen is displayed