### PR TITLE
adding prop file to zero out non-existent privs in ML8

### DIFF
--- a/gradle-ml8.properties
+++ b/gradle-ml8.properties
@@ -1,0 +1,5 @@
+# The data-explorer-ext-amp-role role file references these properties as token. These privileges were introduced in
+# MarkLogic 9, but they aren't needed if deploying Data-Explorer to MarkLogic 8 (and aren't valid)...so replace them with
+# nothing
+termQueryPrivilege=
+adminDatabasePrivilege=


### PR DESCRIPTION
This fix is for issue #130 which is about the inability to deploy to ML8 because data-explorer-ext-amp-role.json references a couple ML9-only privileges. This fix takes advantage of what Rob did to handle this issue when deploying by JAR. So now we have a gradle-ml8.properties file that replaces those privileges in the role file with nothing (when run with -PenvironmentName=ml8) so the deploy will succeed. When deploying for ML9, no need to specify an environment. Wanted to make it that way so deploying to ML9 just worked since most will be/are using that.

To test you'll need an ML8 VM and an ML9 VM.

**Deploying to ML8:**
Make sure to specify the environmentName: gradle -PenvironmentName=ml8 mldeploy. The deployment should be successful. If you do not specify the environmentName, you should see a failure do to an unknown privilege.

**Deploying to ML9:**
Deploy normally (no env): gradle mldeploy. The deployment should be successful. Confirm by checking that the data-explorer-ext-amp-role has the following two privileges
* term-query
* admin-database


Note that testing further by creating Queries will require the pull request for issue #171 to be merged in.