### PR TITLE
Fix for hiding Database Name column in search results

### DIFF
--- a/src/main/ml-modules/root/client/app/adhoc/adhoc.controller.js
+++ b/src/main/ml-modules/root/client/app/adhoc/adhoc.controller.js
@@ -358,6 +358,12 @@ factory('$click', function() {
               return
           }
     		  $scope.message = '';
+
+          // remove 'Database Name' header because we don't want to display that column in the results
+          var colIdx = data['results-header'].indexOf('Database Name');
+          if(colIdx !== -1){
+              data['results-header'].splice(colIdx, 1);
+          }
           if(data['display-order'] === 'alphabetical'){
             var cols = data['results-header'].slice(1).sort(function (a, b) {
               return a.toLowerCase().localeCompare(b.toLowerCase());

--- a/src/main/ml-modules/root/client/app/adhoc/adhoc.html
+++ b/src/main/ml-modules/root/client/app/adhoc/adhoc.html
@@ -93,7 +93,6 @@
                             ng-class="{ 'btn-danger': showMatch[$index], 'btn-primary': !showMatch[$index] }"
                             ng-click="showMatch[$index] = !showMatch[$index]"/>
                             {{ showMatch[$index] ? 'hide' : 'show' }}
-                          </a>
                         </div>
                         <div ng-show="showMatch[$index]">
                           <dl>


### PR DESCRIPTION
This is the fix for issue #177 where the column 'Database Name' was included in the search results (and was blank for each result). This fix removes the column. See the issue to view a screen shot of results with the column. To test:
* Do a search that yields results
* Confirm there is no column called "Database Name" in the results
* Click to export results to CSV file
* Confirm CSV file still has the Database Name column and it is populated