### PR TITLE
Fixes for being able to run mldeploy, create TDE from query, and logi…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        maven { url "http://repo1.maven.org/maven2" }
-        maven { url "http://developer.marklogic.com/maven2/" }
+        maven { url "https://repo1.maven.org/maven2" }
+        maven { url "https://developer.marklogic.com/maven2/" }
     }
 
     dependencies {
@@ -14,7 +14,7 @@ buildscript {
 plugins {
   id "java"
   id "net.saliman.properties" version "1.4.6"
-  id "com.marklogic.ml-gradle" version "3.6.2"
+  id "com.marklogic.ml-gradle" version "3.17.0"
   id "idea"
 }
 
@@ -31,7 +31,7 @@ dependencies {
   testCompile "org.gradle:gradle-tooling-api:4.3"
   testCompile "commons-io:commons-io:2.6"
 
-  compile "com.marklogic:ml-app-deployer:3.9.0"
+  compile "com.marklogic:ml-app-deployer:3.17.0"
 
   // For reading command-line args
   compile "com.beust:jcommander:1.72"

--- a/src/main/ml-config/databases/content-database.json
+++ b/src/main/ml-config/databases/content-database.json
@@ -4,5 +4,7 @@
   "collection-lexicon": true,
   "word-searches": true,
   "uri-lexicon": true,
-  "directory-creation": "manual"
+  "directory-creation": "manual",
+  "schema-database": "%%SCHEMAS_DATABASE%%",
+  "triggers-database": "%%TRIGGERS_DATABASE%%"
 }

--- a/src/main/ml-config/databases/schemas-database.json
+++ b/src/main/ml-config/databases/schemas-database.json
@@ -1,0 +1,3 @@
+{
+    "database-name": "%%SCHEMAS_DATABASE%%"
+}

--- a/src/main/ml-config/databases/triggers-database.json
+++ b/src/main/ml-config/databases/triggers-database.json
@@ -1,0 +1,3 @@
+{
+    "database-name": "%%TRIGGERS_DATABASE%%"
+}

--- a/src/main/ml-config/security/roles/data-explorer-data-role.json
+++ b/src/main/ml-config/security/roles/data-explorer-data-role.json
@@ -1,4 +1,4 @@
 {
   "role-name": "data-explorer-data-role",
-  "description": "Role for Ferret App"
+  "description": "Role for Data Explorer App"
 }

--- a/src/main/ml-config/security/roles/data-explorer-default-role.json
+++ b/src/main/ml-config/security/roles/data-explorer-default-role.json
@@ -1,5 +1,5 @@
 {
   "role-name": "data-explorer-default-role",
-  "description": "Role for Ferret App",
+  "description": "Role for Data Explorer App",
   "role": ["data-explorer-modules-role"]
 }

--- a/src/main/ml-config/security/roles/data-explorer-search-role.json
+++ b/src/main/ml-config/security/roles/data-explorer-search-role.json
@@ -1,6 +1,6 @@
 {
   "role-name": "data-explorer-search-role",
-  "description": "Role for Search user in Ferret App",
+  "description": "Role for Search user in Data Explorer App",
   "role": ["data-explorer-default-role","data-explorer-data-role"],
   "privilege" : [ {
     "privilege-name" : "data-explorer-access",

--- a/src/main/ml-config/security/roles/data-explorer-wizard-role.json
+++ b/src/main/ml-config/security/roles/data-explorer-wizard-role.json
@@ -1,7 +1,7 @@
 {
   "role-name" : "data-explorer-wizard-role",
   "description" : "Role for Data Explorer Wizard",
-  "role" : [ "data-explorer-default-role" ,"data-explorer-data-role"],
+  "role" : [ "data-explorer-default-role" ,"data-explorer-data-role", "tde-admin", "tde-view"],
   "privilege" : [ {
     "privilege-name" : "data-explorer-access",
     "action" : "http://marklogic.com/ps/data-explorer-access",

--- a/src/main/ml-config/security/users/data-explorer-default-user.json
+++ b/src/main/ml-config/security/users/data-explorer-default-user.json
@@ -1,6 +1,6 @@
 {
   "user-name": "default-user",
-  "description": "Ferret Default User",
+  "description": "Data Explorer App Default User",
   "password": "default-user",
   "role": [ "data-explorer-default-role"]
 }

--- a/src/main/ml-config/security/users/data-explorer-search-user.json
+++ b/src/main/ml-config/security/users/data-explorer-search-user.json
@@ -1,6 +1,6 @@
 {
   "user-name": "search-user",
   "password": "password",
-  "description":"Search user for Ferret",
+  "description":"Search user for Data Explorer App",
   "role":["data-explorer-search-role"]
 }

--- a/src/main/ml-config/security/users/data-explorer-wizard-user.json
+++ b/src/main/ml-config/security/users/data-explorer-wizard-user.json
@@ -1,6 +1,6 @@
 {
   "user-name": "wizard-user",
   "password": "password",
-  "description":"Wizard user for Ferret",
+  "description":"Wizard user for Data Explorer App",
   "role":["data-explorer-wizard-role", "data-explorer-search-role"]
 }

--- a/src/main/ml-modules/root/client/app/adhoc/adhoc.controller.js
+++ b/src/main/ml-modules/root/client/app/adhoc/adhoc.controller.js
@@ -47,28 +47,31 @@ factory('$click', function() {
     }];
 
     ctrl.sampleFiletypes = function(dbName) {
-      return $http.get('/api/sample-filetypes', {
-        params: {
-          dbName: encodeURIComponent( (dbName) ? dbName : $scope.selectedDatabase )
-        }
-      })
-      .then(function(response) {
-        if (response.data && response.data.values) {
-          ctrl.filetypeData = response.data;
-          ctrl.makeChart();
-          return response.data.values;
-        }
-        else {
-          ctrl.filetypeData = [{
-            id: 'X',
-            name: 'Empty',
-            color: "#DFDFDF",
-            value: 1
-          }];
-          ctrl.makeChart();
-          return [];
-        }
-      });
+      // only do this if we've got the wizard-user role since the call returns a 401 if we aren't!
+      if(Auth.isWizardUser()){
+        return $http.get('/api/sample-filetypes', {
+          params: {
+            dbName: encodeURIComponent( (dbName) ? dbName : $scope.selectedDatabase )
+          }
+        })
+        .then(function(response) {
+          if (response.data && response.data.values) {
+            ctrl.filetypeData = response.data;
+            ctrl.makeChart();
+            return response.data.values;
+          }
+          else {
+            ctrl.filetypeData = [{
+              id: 'X',
+              name: 'Empty',
+              color: "#DFDFDF",
+              value: 1
+            }];
+            ctrl.makeChart();
+            return [];
+          }
+        });
+      }
     };
 
     ctrl.sampleFiletypes($scope.selectedDatabase);

--- a/src/main/ml-modules/root/server/lib/tde-lib.xqy
+++ b/src/main/ml-modules/root/server/lib/tde-lib.xqy
@@ -1,7 +1,7 @@
 xquery version "1.0-ml";
 
 module namespace tde-lib = "http://www.marklogic.com/data-explore/lib/tde-lib";
-
+import module namespace xu = "http://marklogic.com/data-explore/lib/xdmp-utils" at "/server/lib/xdmp-utils.xqy";
 import module namespace tde = "http://marklogic.com/xdmp/tde" at "/MarkLogic/tde.xqy";
 
 declare option xdmp:mapping "false";
@@ -17,7 +17,7 @@ declare function tde-lib:delete-tde-for-query-view($form-query as element(formQu
 declare function tde-lib:has-tde($form-query as element(formQuery),$view as element(view)) as xs:boolean {
     let $database := $form-query/database/fn:string()
     let $schemas-database := xdmp:schema-database(xdmp:database($database))
-    return xdmp:invoke-function(function() {
+    return xu:invoke-function(function() {
         fn:exists(fn:doc(tde-lib:get-tde-uri($form-query,$view/name/fn:string())))
     },<options xmlns="xdmp:eval">
         <update>false</update>
@@ -79,7 +79,7 @@ declare function tde-lib:create-or-update-tde($create-tde as xs:boolean,$form-qu
                         </rows>
                     </template>
                     let $database := $form-query/database/fn:string()
-                    let $_ := xdmp:invoke-function(function() {
+                    let $_ := xu:invoke-function(function() { 
                         tde:template-insert(tde-lib:get-tde-uri($form-query,$view/name/fn:string()),$tde)
                     },<options xmlns="xdmp:eval">
                         <update>true</update>


### PR DESCRIPTION
…n/click search as search-user
Fixes for issue #197 
* Upgraded build.gradle to use https for the the repos. In the past we've used http because I think the java keystore didn't have the correct cert to do https. But now when I tried to do an mldeploy it said HTTPS was required. **Note: this requires adding the correct cert or using a newer java (I used JDK11)**
* Upgraded to use the most recent versions ml-gradle and ml-app-deployer (3.17.0). The version of ml-gradle being used was not deploying the modules (see issue).
* Added a triggers and schemas database config and updated the content-database.json to use them because there was no schemas database configured and TDE creation recommends using a specific one rather than the Schemas database that is installed by default. With this, at least our sample data will have a schemas database to hold TDEs.
* Added the tde-admin and tde-view roles to the data-explorer-wizard role since they are required to use the protected collection for TDEs and to view TDEs. 
* Updated calls to xdmp:invoke-function in the tde-lib.xqy library to use xu:invoke-function (from /root/server/lib/xdmp-utils.xqy) because that function is amped with the anyuri priv which allows the TDEs to be written. Wasn't able to create the TDE without this due to URI-PRIV error.
* Updated adhoc.controller.js to only call the /api/sample-filtetypes endpoint if the user has the wizard-user role. Otherwise was auto logging the user out (see issue)
* Updated user/role definitions that had ferret in the description with Data Explorer instead