### PR TITLE
Fix for showing an error message when no schemas database exists

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        maven { url "http://repo1.maven.org/maven2" }
-        maven { url "http://developer.marklogic.com/maven2/" }
+        maven { url "https://repo1.maven.org/maven2" }
+        maven { url "https://developer.marklogic.com/maven2/" }
     }
 
     dependencies {
@@ -14,7 +14,7 @@ buildscript {
 plugins {
   id "java"
   id "net.saliman.properties" version "1.4.6"
-  id "com.marklogic.ml-gradle" version "3.6.2"
+  id "com.marklogic.ml-gradle" version "3.17.0"
   id "idea"
 }
 
@@ -31,7 +31,7 @@ dependencies {
   testCompile "org.gradle:gradle-tooling-api:4.3"
   testCompile "commons-io:commons-io:2.6"
 
-  compile "com.marklogic:ml-app-deployer:3.9.0"
+  compile "com.marklogic:ml-app-deployer:3.17.0"
 
   // For reading command-line args
   compile "com.beust:jcommander:1.72"

--- a/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard-field-selection.controller.js
+++ b/src/main/ml-modules/root/client/app/adhoc-wizard/adhoc-wizard-field-selection.controller.js
@@ -298,8 +298,19 @@ angular.module('demoApp')
                 renderResultsModal('success', crudType + crudAction + 'successfully.');
                 $rootScope.noQueries = false;
             }
-        }).error(function(data, status){
-          renderResultsModal('error', 'Server Error. Please try again later.');
+        }).error(function(response, status){
+          // default error message in case we don't understand what is returned
+          let errorMessage = 'Error: Please try again later.';
+
+          // Create a better error message if we can
+          if(response.hasOwnProperty("error") && response.error.length > 0){
+            if(response.error[0].code === 'XDMP-NODB'){
+              errorMessage = "Error: Database '" + data.database + "' does not have a schemas database associated with it.";
+            }else {
+              errorMessage = "Error: " + response.error[0].code + ": " + response.error[0].message;
+            }
+          }
+          renderResultsModal('error', errorMessage);
         });
       }
     };

--- a/src/main/ml-modules/root/server/error.xqy
+++ b/src/main/ml-modules/root/server/error.xqy
@@ -2,30 +2,15 @@ xquery version "1.0-ml";
 
 import module namespace cfg = "http://www.marklogic.com/data-explore/lib/config" at "/server/lib/config.xqy";
 import module namespace check-user-lib = "http://www.marklogic.com/data-explore/lib/check-user-lib"  at "/server/lib/check-user-lib.xqy";
+import module namespace json="http://marklogic.com/xdmp/json" at "/MarkLogic/json/json.xqy";
+
+declare namespace error = "http://marklogic.com/xdmp/error";
 declare option xdmp:mapping "false";
 declare variable $error:errors as node()* external;
 
-xdmp:set-response-content-type("text/html"),
-    '<!DOCTYPE html>',
-    <html>
-        <head>
-            <title>{$cfg:app-title} - Error</title>
-            <!--<link href="/css/status.css" type="text/css" rel="stylesheet"/>-->
-        </head>
-        <body>  
-        <div id="container">
-                <div id="header">
-                    <a href="/"><h1>{$cfg:app-title}</h1></a>
-                    <!--div id="headerImg"/-->
-                    <br class="floatclear"/>
-                </div>
-                <div id="body" class="contentfull">
-                    <div class="section" id="dbcontent">
-                        <h2>Error </h2>
-                        <p>There has been an error.</p>
-                        <p>{xdmp:quote($error:errors)}</p>
-                    </div>
-                </div>
-        </div>
-        </body>
-    </html>
+let $config := json:config("custom")
+let $_ := map:put($config, "array-element-names", (xs:QName("error:error"), xs:QName("error:stack"),xs:QName("error:frame"), xs:QName("error:variable")))
+return (
+    xdmp:set-response-content-type("application/json"),
+    json:transform-to-json($error:errors, $config)
+)


### PR DESCRIPTION
For Issue #188 

Displaying errors has been a pain point for a while and this is one way to go about a fix. Historically, data-explorer was more of a server-only app where the UI was generated on the server. Because of that, errors were created/returned in HTML via the error.xqy file and rendered directly in the browser. Some time ago, data-explorer was changed to be more client server where the client is written using angularJS. With this methodology, errors returned from REST calls that are a full HTML page weren't very useful. As such I changed error.xqy to convert the error stack to JSON and changed the content type to application/json. This will allow us to inspect the error from angularJS and display something more meaningful than "...an error occurred". It will also let us easily inspect the error in the Network tab of the browser dev tools. 

I've only updated the call to create a query to inspect the JSON return and show a better message if there is no schemas database. The rest of the places where we display an error message should continue to work as is (with the vague msg), but we can change to show a more specific error in the future.

In doing this fix I have also assumed the requirement that a content database will have a schemas database associated with it. If this isn't a fair assumption, we'll have to do something else but it seems troublesome to support creating TDEs and not require a schemas database.

I also included changes to the build.gradle file so the artifacts are retrieved from repos using HTTPS and did an ml-gradle and ml-app-deployer bump to 3.17.0. These changes are also in PR #198 but I need them here as well so I could run ml-deploy to develop and test. Note this will likely require a JDK newer than 8 so you get the cert that allows HTTPS access to the repos. 

